### PR TITLE
[drivers] fix deprecated parameter name warning reported by progressbar2

### DIFF
--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -94,7 +94,7 @@ def identify_many(scenes):
         a list of pyroSAR metadata handlers
     """
     idlist = []
-    pbar = pb.ProgressBar(maxval=len(scenes)).start()
+    pbar = pb.ProgressBar(max_value=len(scenes)).start()
     for i, scene in enumerate(scenes):
         if isinstance(scene, ID):
             idlist.append(scene)
@@ -1856,7 +1856,7 @@ class Archive(object):
             raise RuntimeError('directory cannot be written to')
         failed = []
         double = []
-        pbar = pb.ProgressBar(maxval=len(scenelist)).start()
+        pbar = pb.ProgressBar(max_value=len(scenelist)).start()
         cursor = self.conn.cursor()
         for i, scene in enumerate(scenelist):
             new = os.path.join(directory, os.path.basename(scene))


### PR DESCRIPTION
Warnings reported:
```
pyroSAR/tests/test_drivers.py::test_identify_many_fail
  pyrosar/env/lib/python3.6/site-packages/progressbar2-3.38.0-py3.6.egg/progressbar/bar.py:242: DeprecationWarning: The usage of `maxval` is deprecated, please use `max_value` instead
    '`max_value` instead', DeprecationWarning)

pyroSAR/tests/test_drivers.py::test_archive
  pyrosar/env/lib/python3.6/site-packages/progressbar2-3.38.0-py3.6.egg/progressbar/bar.py:242: DeprecationWarning: The usage of `maxval` is deprecated, please use `max_value` instead
    '`max_value` instead', DeprecationWarning)
```
Tested on: platform linux -- Python 3.6.7, pytest-3.10.1, py-1.7.0, pluggy-0.8.0

Has been deprecated since v3.0 of `progressbar2` (May 2015).