### PR TITLE
Support minimum set of Python packaging trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(name='pyroSAR',
       version='0.5.1',
       description='a framework for large-scale SAR satellite data processing',
       classifiers=[
+          'License :: OSI Approved :: MIT License',
           'Programming Language :: Python',
       ],
       install_requires=['progressbar2',

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ setup(name='pyroSAR',
       description='a framework for large-scale SAR satellite data processing',
       classifiers=[
           'License :: OSI Approved :: MIT License',
+          'Operating System :: Microsoft :: Windows',
+          'Operating System :: POSIX :: Linux',
           'Programming Language :: Python',
       ],
       install_requires=['progressbar2',


### PR DESCRIPTION
`classifiers` tell the PyPi index and `pip` additional metadata about a package.

The Python Packaging User Guide [recommends the following at minimum](https://packaging.python.org/tutorials/packaging-projects/#classifiers):

> ...You should always include at least which version(s) of Python your package works on, which
> license your package is available under, and which operating systems your package will work on.
> For a complete list of classifiers, see https://pypi.org/classifiers/.

In particular, these allow PyPi users to programmatically locate pyroSAR as an project made available under an open source license and supported on certain operating systems.

For example:
- https://pypi.org/search/?c=License+%3A%3A+OSI+Approved+%3A%3A+MIT+License
- https://pypi.org/search/?c=Operating+System+%3A%3A+POSIX+%3A%3A+Linux

To improve the discoverability of pyroSAR, let's add the minimum recommended trove classifiers.