### PR TITLE
[test_ancillary.test_groupby] new test function for Ancillary.groupby()

### DIFF
--- a/pyroSAR/tests/test_ancillary.py
+++ b/pyroSAR/tests/test_ancillary.py
@@ -82,6 +82,44 @@ def test_rescale():
         anc.rescale([1000, 1000])
 
 
+def test_groupby():
+    """
+    Test correct grouping of filenames by their attributes
+    Methodology is to provide a list of partially overlapping filenames
+    and ensure the resultant list of lists contains the correct entry numbers
+    """
+    filenames = ['S1A__IW___A_20150309T173017_VV_grd_mli_geo_norm_db.tif',
+                 'S1A__IW___A_20150309T173017_HH_grd_mli_geo_norm_db.tif',
+                 'S2A__IW___A_20180309T173017_HH_grd_mli_geo_norm_db.tif']
+    sensor_groups = anc.groupby(filenames, 'sensor')
+    print(sensor_groups)
+    assert len(sensor_groups) == 2
+    assert isinstance(sensor_groups[0], list)
+    assert len(sensor_groups[0]) == 2
+
+    filenames += ['S2A__IW___A_20180309T173017_VV_grd_mli_geo_norm_db.tif']
+
+    polarization_groups = anc.groupby(filenames, 'polarization')
+    print(polarization_groups)
+    assert len(polarization_groups) == 2
+    assert isinstance(polarization_groups[0], list)
+    assert isinstance(polarization_groups[1], list)
+    assert len(polarization_groups[0]) == 2
+    assert len(polarization_groups[1]) == 2
+
+    filenames += ['S2A__IW___A_20180309T173017_HV_grd_mli_geo_norm_db.tif']
+
+    polarization_groups = anc.groupby(filenames, 'polarization')
+    print(polarization_groups)
+    assert len(polarization_groups) == 3
+    assert isinstance(polarization_groups[0], list)
+    assert isinstance(polarization_groups[1], list)
+    assert isinstance(polarization_groups[2], list)
+    assert len(polarization_groups[0]) == 2
+    assert len(polarization_groups[1]) == 1
+    assert len(polarization_groups[2]) == 2
+
+
 def test_groupbyTime():
     filenames = ['S1__IW___A_20151212T120000',
                  'S1__IW___A_20151212T120100',


### PR DESCRIPTION
Concise test to modestly increase test coverage within `ancillary`.

Similar to the sibling tests, the methodology is to provide a list of partially overlapping filenames, put them through `ancillary.groupby()` and ensure the resultant list of lists contains the correct entry numbers.

Tested to confirm working with the following Pythons:
* Python 3.4
* Python 3.5
* Python 3.6
* Python 3.7