### PR TITLE
automatic download and preparation of DEM data

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ version = '0.7'
 # The full version, including alpha/beta/rc tags.
 release = '0.7'
 
-autodoc_mock_imports = ['osgeo', 'spatialist']
+autodoc_mock_imports = ['osgeo']
 
 # If your documentation needs a minimal Sphinx version, state it here.
 needs_sphinx = '1.6'

--- a/docs/pyroSAR.rst
+++ b/docs/pyroSAR.rst
@@ -63,13 +63,14 @@ SRTM tools
 ----------
 
 .. automodule:: pyroSAR.gamma.srtm
-    :members: dempar, fill, hgt, hgt_collect, makeSRTM, mosaic, swap
+    :members: dem_autocreate, dempar, fill, hgt, hgt_collect, makeSRTM, mosaic, swap
     :undoc-members:
     :show-inheritance:
 
     .. autosummary::
         :nosignatures:
 
+        dem_autocreate
         dempar
         fill
         hgt

--- a/docs/pyroSAR.rst
+++ b/docs/pyroSAR.rst
@@ -149,6 +149,14 @@ Sentinel-1 Tools
     :undoc-members:
     :show-inheritance:
 
+Auxiliary Data Tools
+====================
+
+.. automodule:: pyroSAR.auxdata
+    :members: dem_autoload
+    :undoc-members:
+    :show-inheritance:
+
 Datacube Tools
 ==============
 .. automodule:: pyroSAR.datacube_util

--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -15,6 +15,15 @@ from spatialist.auxil import gdalbuildvrt
 
 
 class Handler:
+    """
+    | An interface to obtain auxiliary data for selected SAR scenes
+    | The files are downloaded into the ESA SNAP auxdata directory structure
+    
+    Parameters
+    ----------
+    scenes: list
+        a list of SAR scenes to obtain auxiliary data for
+    """
     def __init__(self, scenes):
         self.scenes = [identify(scene) if isinstance(scene, str) else scene for scene in scenes]
         try:
@@ -43,6 +52,19 @@ class Handler:
         return locals
     
     def srtm_1sec_hgt(self, vrt=None):
+        """
+        obtain SRTM 1arcsec DEM tiles in HGT format
+        
+        Parameters
+        ----------
+        vrt: str or None
+            an optional GDAL VRT file created from the obtained DEM tiles
+
+        Returns
+        -------
+        list or str
+            the names of the obtained files or the name of the VRT file
+        """
         url = 'https://step.esa.int/auxdata/dem/SRTMGL1'
         outdir = os.path.join(self.auxdatapath, 'dem', 'SRTM 1Sec HGT')
         files = [x.replace('hgt', 'SRTMGL1.hgt.zip') for x in
@@ -55,6 +77,19 @@ class Handler:
         return locals
     
     def srtm_3sec(self, vrt=None):
+        """
+        obtain SRTM 3arcsec DEM tiles in GeoTiff format
+        
+        Parameters
+        ----------
+        vrt: str or None
+            an optional GDAL VRT file created from the obtained DEM tiles
+
+        Returns
+        -------
+        list or str
+            the names of the obtained files or the name of the VRT file
+        """
         url = 'http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF'
         outdir = os.path.join(self.auxdatapath, 'dem', 'SRTM 3Sec')
         files = []

--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -1,0 +1,62 @@
+import os
+import sys
+
+if sys.version_info >= (3, 0):
+    from urllib.request import urlopen
+    from urllib.error import HTTPError
+else:
+    from urllib2 import urlopen, HTTPError
+
+from . import identify
+from .snap import ExamineSnap
+
+from spatialist.ancillary import dissolve
+
+
+class Handler:
+    def __init__(self, scenes):
+        self.scenes = [identify(scene) if isinstance(scene, str) else scene for scene in scenes]
+        try:
+            self.auxdatapath = ExamineSnap().auxdatapath
+        except AttributeError:
+            self.auxdatapath = os.path.join(os.path.expanduser('~'), '.snap', 'auxdata')
+    
+    @staticmethod
+    def __retrieve(url, filenames, outdir):
+        files = list(set(filenames))
+        locals = []
+        for file in files:
+            infile = os.path.join(url, file)
+            outfile = os.path.join(outdir, file)
+            if not os.path.isfile(outfile):
+                try:
+                    input = urlopen(infile)
+                    print('downloading file {}'.format(infile))
+                except HTTPError:
+                    continue
+                with open(outfile, 'wb') as output:
+                    output.write(input.read())
+                input.close()
+            if os.path.isfile(outfile):
+                locals.append(outfile)
+        return locals
+    
+    def srtm_1sec_hgt(self):
+        url = 'https://step.esa.int/auxdata/dem/SRTMGL1'
+        outdir = os.path.join(self.auxdatapath, 'dem', 'SRTM 1Sec HGT')
+        files = [x.replace('hgt', 'SRTMGL1.hgt.zip') for x in
+                 list(set(dissolve([scene.getHGT() for scene in self.scenes])))]
+        locals = self.__retrieve(url, files, outdir)
+        return locals
+    
+    def srtm_3sec(self):
+        url = 'http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF'
+        outdir = os.path.join(self.auxdatapath, 'dem', 'SRTM 3Sec')
+        files = []
+        for scene in self.scenes:
+            corners = scene.getCorners()
+            x_id = [int((corners[x] + 180) // 5) + 1 for x in ['xmin', 'xmax']]
+            y_id = [int((60 - corners[x]) // 5) + 1 for x in ['ymin', 'ymax']]
+            files.extend(['srtm_{:02d}_{:02d}.zip'.format(x, y) for x in x_id for y in y_id])
+        locals = self.__retrieve(url, files, outdir)
+        return locals

--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -14,7 +14,7 @@ from spatialist.ancillary import dissolve, finder
 from spatialist.auxil import gdalbuildvrt
 
 
-def dem_autoload(geometries, demType, vrt=None):
+def dem_autoload(geometries, demType, vrt=None, username=None, password=None):
     """
     obtain all relevant DEM tiles for selected geometries
 
@@ -39,6 +39,10 @@ def dem_autoload(geometries, demType, vrt=None):
 
     vrt: str or None
         an optional GDAL VRT file created from the obtained DEM tiles
+    username: str or None
+        (optional) the user name for services requiring registration
+    password: str or None
+        (optional) the password for the registration account
 
     Returns
     -------

--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -13,6 +13,48 @@ from spatialist.ancillary import dissolve, finder
 from spatialist.auxil import gdalbuildvrt
 
 
+def dem_autoload(geometries, demType, vrt=None):
+    """
+    obtain all relevant DEM tiles for selected geometries
+
+    Parameters
+    ----------
+    geometries: list
+        a list of :class:`spatialist.vector.Vector` geometries to obtain DEM data for; CRS must be WGS84 LatLon (EPSG 4326)
+    demType: str
+        the type fo DEM to be used; current options:
+
+        - 'AW3D30' (ALOS Global Digital Surface Model "ALOS World 3D - 30m (AW3D30)")
+
+          * url: ftp://ftp.eorc.jaxa.jp/pub/ALOS/ext1/AW3D30/release_v1804
+
+        - 'SRTM 1Sec HGT'
+
+          * url: https://step.esa.int/auxdata/dem/SRTMGL1
+
+        - 'SRTM 3sec'
+
+          * url: http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF
+
+    vrt: str or None
+        an optional GDAL VRT file created from the obtained DEM tiles
+
+    Returns
+    -------
+    list or str
+        the names of the obtained files or the name of the VRT file
+    """
+    with DEMHandler(geometries) as handler:
+        if demType == 'AW3D30':
+            return handler.aw3d30(vrt)
+        elif demType == 'SRTM 1Sec HGT':
+            return handler.srtm_1sec_hgt(vrt)
+        elif demType == 'SRTM 3Sec':
+            return handler.srtm_3sec(vrt)
+        else:
+            raise RuntimeError('demType unknown')
+
+
 class DEMHandler:
     """
     | An interface to obtain DEM data for selected geometries
@@ -20,7 +62,7 @@ class DEMHandler:
     
     Parameters
     ----------
-    geometries: list of spatialist.Vector
+    geometries: list of spatialist.vector.Vector
         a list of geometries
     """
     

--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -36,6 +36,11 @@ def dem_autoload(geometries, demType, vrt=None, username=None, password=None):
         - 'SRTM 3sec'
 
           * url: http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF
+        
+        - 'TDX90m'
+        
+          * registration:  https://geoservice.dlr.de/web/dataguide/tdm90
+          * url: ftpes://tandemx-90m.dlr.de
 
     vrt: str or None
         an optional GDAL VRT file created from the obtained DEM tiles
@@ -56,6 +61,10 @@ def dem_autoload(geometries, demType, vrt=None, username=None, password=None):
             return handler.srtm_1sec_hgt(vrt)
         elif demType == 'SRTM 3Sec':
             return handler.srtm_3sec(vrt)
+        elif demType == 'TDX90m':
+            return handler.tdx90m(username=username,
+                                  password=password,
+                                  vrt=vrt)
         else:
             raise RuntimeError('demType unknown')
 

--- a/pyroSAR/gamma/srtm.py
+++ b/pyroSAR/gamma/srtm.py
@@ -205,16 +205,21 @@ def dem_autocreate(geometry, demType, outfile, buffer=0.01, logpath=None, userna
         gdalwarp(vrt, dem, {'format': 'GTiff',
                             'outputBounds': (ext['xmin'], ext['ymin'], ext['xmax'], ext['ymax'])})
         
+        outfile_tmp = os.path.join(tmpdir, os.path.basename(outfile))
+        
         print('geoid correction and conversion to Gamma format')
         diff.srtm2dem(SRTM_DEM=dem,
-                      DEM=outfile,
-                      DEM_par=outfile + '.par',
+                      DEM=outfile_tmp,
+                      DEM_par=outfile_tmp + '.par',
                       gflg=2,
                       geoid='-',
                       logpath=logpath,
                       outdir=tmpdir)
-        par2hdr(outfile + '.par', outfile + '.hdr')
-    
+        par2hdr(outfile_tmp + '.par', outfile_tmp + '.hdr')
+        
+        for suffix in ['', '.par', '.hdr']:
+            shutil.copyfile(outfile_tmp + suffix, outfile + suffix)
+        
     except RuntimeError as e:
         raise e
     finally:

--- a/pyroSAR/gamma/srtm.py
+++ b/pyroSAR/gamma/srtm.py
@@ -209,11 +209,16 @@ def dem_autocreate(geometry, demType, outfile, buffer=0.01, logpath=None, userna
         
         outfile_tmp = os.path.join(tmpdir, os.path.basename(outfile))
         
-        print('geoid correction and conversion to Gamma format')
-        
         # The heights of the TanDEM-X DEM products are ellipsoidal heights, all others are EGM96 Geoid heights
         # Gamma works only with Ellipsoid heights and the offset needs to be corrected
-        gflg = 0 if demType == 'TDX90m' else 2
+        if demType == 'TDX90m':
+            gflg = 0
+            message = 'conversion to Gamma format'
+        else:
+            gflg =2
+            message = 'geoid correction and conversion to Gamma format'
+
+        print(message)
         
         diff.srtm2dem(SRTM_DEM=dem,
                       DEM=outfile_tmp,

--- a/pyroSAR/gamma/srtm.py
+++ b/pyroSAR/gamma/srtm.py
@@ -155,6 +155,8 @@ def dem_autocreate(geometry, demType, outfile, buffer=0.01, logpath=None, userna
 
     - create a mosaic GeoTiff of the same spatial extent as the input geometry plus a defined buffer using gdalwarp
     - subtract the EGM96-WGS84 Geoid-Ellipsoid difference and convert the result to Gamma format using Gamma command srtm2dem
+    
+      * this correction is not done for TanDEM-X data, which contains ellipsoid heights; see `here <https://geoservice.dlr.de/web/dataguide/tdm90>`_
 
     Parameters
     ----------
@@ -208,10 +210,15 @@ def dem_autocreate(geometry, demType, outfile, buffer=0.01, logpath=None, userna
         outfile_tmp = os.path.join(tmpdir, os.path.basename(outfile))
         
         print('geoid correction and conversion to Gamma format')
+        
+        # The heights of the TanDEM-X DEM products are ellipsoidal heights, all others are EGM96 Geoid heights
+        # Gamma works only with Ellipsoid heights and the offset needs to be corrected
+        gflg = 0 if demType == 'TDX90m' else 2
+        
         diff.srtm2dem(SRTM_DEM=dem,
                       DEM=outfile_tmp,
                       DEM_par=outfile_tmp + '.par',
-                      gflg=2,
+                      gflg=gflg,
                       geoid='-',
                       logpath=logpath,
                       outdir=tmpdir)

--- a/pyroSAR/gamma/srtm.py
+++ b/pyroSAR/gamma/srtm.py
@@ -143,7 +143,7 @@ def transform(infile, outfile, posting=90):
     par2hdr(outfile + '.par', outfile + '.hdr')
 
 
-def dem_autocreate(geometry, demType, outfile, buffer=0.01, logpath=None):
+def dem_autocreate(geometry, demType, outfile, buffer=0.01, logpath=None, username=None, password=None):
     """
     | automatically create a DEM in Gamma format for a defined spatial geometry
     | the following steps will be performed:
@@ -168,6 +168,10 @@ def dem_autocreate(geometry, demType, outfile, buffer=0.01, logpath=None):
         a buffer in degrees to create around the DEM file
     logpath: str
         a directory to write Gamma logfiles to
+    username: str or None
+        (optional) the user name for services requiring registration; see :func:`~pyroSAR.auxdata.dem_autoload`
+    password: str or None
+        (optional) the password for the registration account
 
     Returns
     -------
@@ -188,7 +192,7 @@ def dem_autocreate(geometry, demType, outfile, buffer=0.01, logpath=None):
         dem = os.path.join(tmpdir, 'dem.tif')
         
         print('collecting DEM tiles')
-        vrt = dem_autoload([geometry], demType, vrt=vrt)
+        vrt = dem_autoload([geometry], demType, vrt=vrt, username=username, password=password)
         
         ext = geometry.extent
         


### PR DESCRIPTION
This pull request adds a new module auxdata, which will eventually contain all functionalities for handling auxiliary data. Currently it contains a class DEMHandler, which offers an interface for downloading DEM data from different sources and combining individual tiles via a GDAL VRT file. A function dem_autoload offers simplified access to this class.

Furthermore a new function gamma.srtm.dem_autocreate uses the function dem_autoload to prepare the different DEM options supported by class DEMHandler for processing in Gamma, i.e. mosaicing of the tiles, subtracting the EGM96-WGS84 Geoid-Ellipsoid difference and conversion to Gamma format.