### PR TITLE
create Gamma DEM files in arbitrary coordinate reference systems

### DIFF
--- a/pyroSAR/gamma/auxil.py
+++ b/pyroSAR/gamma/auxil.py
@@ -118,7 +118,7 @@ class ISPPar(object):
         
         Parameters
         ----------
-        nodata: str or None
+        nodata: int, float or None
             a no data value to write to the HDR file via attribute 'data ignore value'
         
         Returns
@@ -183,7 +183,7 @@ def par2hdr(parfile, hdrfile, modifications=None, nodata=None):
         the ENVI HDR file
     modifications: dict or None
         a dictionary containing value deviations to write to the HDR file
-    nodata: str or None
+    nodata: int, float or None
         a no data value to write to the HDR file via attribute 'data ignore value'
 
     Returns

--- a/pyroSAR/gamma/srtm.py
+++ b/pyroSAR/gamma/srtm.py
@@ -162,9 +162,13 @@ def dem_autocreate(geometry, demType, outfile, buffer=0.01, t_srs=4326, tr=None,
       plus a defined buffer using ``gdalwarp``
     - subtract the EGM96-WGS84 Geoid-Ellipsoid difference and convert the result
       to Gamma format using Gamma command ``srtm2dem``
-
+    
       * this correction is not done for TanDEM-X data, which contains ellipsoid
         heights; see `here <https://geoservice.dlr.de/web/dataguide/tdm90>`_
+    
+    - if the command ``create_dem_par`` accepts a parameter EPSG and the command ``dem_import`` exists,
+      an arbitrary CRS can be defined via parameter ``t_srs``. In this case and if parameter ``t_srs`` is not kept at
+      its default of 4326, conversion to Gamma format is done with command ``dem_import`` instead of ``srtm2dem``
 
     Parameters
     ----------

--- a/pyroSAR/gamma/srtm.py
+++ b/pyroSAR/gamma/srtm.py
@@ -271,9 +271,7 @@ def dem_autocreate(geometry, demType, outfile, buffer=0.01, t_srs=4326, tr=None,
                                 EPSG=epsg)
             dem_import_pars = {'input_DEM': dem,
                                'DEM': outfile_tmp,
-                               'DEM_par': outfile_tmp + '.par',
-                               'input_type': 0,  # GeoTIFF / GDAL supported raster format (default)
-                               'priority': 1}  # input DEM parameters have priority (default)
+                               'DEM_par': outfile_tmp + '.par'}
             if gflg == 2:
                 home = ExamineGamma().home
                 egm96 = os.path.join(home, 'DIFF', 'scripts', 'egm96.dem')

--- a/pyroSAR/gamma/srtm.py
+++ b/pyroSAR/gamma/srtm.py
@@ -180,8 +180,10 @@ def dem_autocreate(geometry, demType, outfile, buffer=0.01, t_srs=4326, tr=None,
         A target geographic reference system in WKT, EPSG, PROJ4 or OPENGIS format.
         See function :func:`spatialist.auxil.crsConvert()` for details.
         Default: `4326 <http://spatialreference.org/ref/epsg/4326/>`_.
-    tr: tuple
-        the target resoultion as (xres, yres)
+    tr: tuple or None
+        the target resolution as (xres, yres) in units of ``t_srs``; if ``t_srs`` is kept at its default value of 4326,
+        ``tr`` does not need to be defined and the original resolution is preserved;
+        in all other cases the default of None is rejected
     logpath: str
         a directory to write Gamma logfiles to
     username: str or None
@@ -280,7 +282,7 @@ def dem_autocreate(geometry, demType, outfile, buffer=0.01, t_srs=4326, tr=None,
             
             diff.dem_import(**dem_import_pars)
         
-        par2hdr(outfile_tmp + '.par', outfile_tmp + '.hdr')
+        par2hdr(outfile_tmp + '.par', outfile_tmp + '.hdr', nodata=0)
         
         for suffix in ['', '.par', '.hdr']:
             shutil.copyfile(outfile_tmp + suffix, outfile + suffix)


### PR DESCRIPTION
function `gamma.srtm.dem_autocreate` now takes two new parameters t_srs (target spatial reference system) and tr (target resolution), which enable reprojecting the original DEM tiles. In case the installed version of Gamma contains the command `dem_import` and the command `create_dem_par` takes a parameter EPSG, DEMs in any CRS can be imported into Gamma format.