### PR TITLE
[_dev_config.py.product_pattern] allow for other file extensions

### DIFF
--- a/pyroSAR/_dev_config.py
+++ b/pyroSAR/_dev_config.py
@@ -23,7 +23,7 @@ product_pattern = r'(?:.*[/\\]|)' \
                   r'(?:_(?P<extensions>\w*)|)' \
                   r')_' \
                   r'(?P<polarization>[HV]{2})_' \
-                  r'(?P<proc_steps>\w*).tif$'
+                  r'(?P<proc_steps>\w*).*$'
 
 
 class Storage(dict):


### PR DESCRIPTION
We want to be able to parse the file names regardless of
the file extension.
Everything which is behind a . is ignored at the end of the filename.