### PR TITLE
Travis CI: install GDAL Python binding inside virtual environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
       - python3-gdal
       - libspatialite-dev
       - libsqlite3-mod-spatialite
-      - swig2.0
+      - swig
       - libproj-dev
       - gdal-bin
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
       - swig
       - libproj-dev
       - gdal-bin
+      - python3-dev
 
 # currently 3.5 is the only version that works together with system site apt_packages:
 # this might change in the future; an alternative could be to install  the GDAL python bindings
@@ -39,7 +40,8 @@ before_install:
 
 install:
   - pip install --ignore-installed six # install six inside the venv since the system version is too old
-  - pip install GDAL==$(gdal-config --version) --global-option=build_ext --global-option=\"$(gdal-config --cflags)\"
+  - pip install numpy
+  - pip install GDAL==$(gdal-config --version) --global-option=build_ext --global-option="$(gdal-config --cflags)"
   - pip install -r requirements-dev.txt
   - pip install coveralls coverage
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,11 @@ addons:
       - sourceline: 'ppa:ubuntugis/ppa'
     packages:
       - libgdal-dev
-      - libudunits2-dev
-      - python-gdal
-      - python3-gdal
-      - libspatialite-dev
-      - libsqlite3-mod-spatialite
-      - swig
-      - libproj-dev
       - gdal-bin
+      - libsqlite3-mod-spatialite
+      - libproj-dev
       - python3-dev
 
-# currently 3.5 is the only version that works together with system site apt_packages:
-# this might change in the future; an alternative could be to install  the GDAL python bindings
-# directly in the venv; see e.g. here: https://gist.github.com/cspanring/5680334
 python:
   - '3.7'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: python
 sudo: required
 cache:
@@ -30,10 +30,7 @@ addons:
 # this might change in the future; an alternative could be to install  the GDAL python bindings
 # directly in the venv; see e.g. here: https://gist.github.com/cspanring/5680334
 python:
-  - '3.5'
-
-virtualenv:
-  system_site_packages: true
+  - '3.7'
 
 before_install:
   - wget -O esa-snap_sentinel_unix_7_0.sh https://step.esa.int/downloads/7.0/installers/esa-snap_sentinel_unix_7_0.sh
@@ -42,6 +39,7 @@ before_install:
 
 install:
   - pip install --ignore-installed six # install six inside the venv since the system version is too old
+  - pip install GDAL==$(gdal-config --version) --global-option=build_ext --global-option=\"$(gdal-config --cflags)\"
   - pip install -r requirements-dev.txt
   - pip install coveralls coverage
   - python setup.py install


### PR DESCRIPTION
Before, the Python binding was installed via apt and used as system site package inside the virtual environment. This prevented the use of the latest Python version.  
Now  the binding is installed inside the virtual environment linking to the apt installation of GDAL.  
Furthermore, the Ubuntu distribution was changed to bionic, the Python version increased to 3.7 and the list of apt-installed packages reduced.