### PR TITLE
Fix graph splitting when exporting extra files

### DIFF
--- a/pyroSAR/snap/auxil.py
+++ b/pyroSAR/snap/auxil.py
@@ -448,7 +448,7 @@ def split(xmlfile, groups):
         # add a Write node to all dangling nodes
         counter = 0
         for node in new:
-            if new.successors(node.id) == [] and node.id != 'Write':
+            if new.successors(node.id) == [] and not node.id.startswith('Write'):
                 write = parse_node('Write')
                 new.insert_node(write, before=node.id)
                 id = str(position) if counter == 0 else '{}-{}'.format(position, counter)


### PR DESCRIPTION
Hi there! First, thanks for making this project - it's been very helpful for me in wrapping SNAP, especially the graph splitting functionality.

I ran into an issue with `pyroSAR==0.10.1` (and also `0.9.*`) when splitting up the preprocessing graph if I request that angle maps be exported (via `export_extra`). The error was `KeyError: 'Write (2)'`, which happened when trying to add a Write node to the nodes responsible for exporting the angle maps. These nodes are already write nodes so they can be left alone, which I accomplished by skipping any nodes that begin with "Write".

The issue and fix seemed simple enough so I made a PR. Happy to make a issue request with further information if that'd be helpful