### PR TITLE
Feature/new suffixes

### DIFF
--- a/pyroSAR/_dev_config.py
+++ b/pyroSAR/_dev_config.py
@@ -89,8 +89,11 @@ class Storage(dict):
 # LOOKUP
 # ==============================================================================
 snap_suffix = {'Apply-Orbit-File': 'Orb',
+               'Back-Geocoding': 'BG',
                'Calibration': 'Cal',
                'Cross-Correlation': '',
+               'GoldsteinPhaseFiltering': 'GPF',
+               'Interferogram': 'I',
                'LinearToFromdB': 'dB',
                'Multilook': 'ML',
                'Read': '',
@@ -98,11 +101,14 @@ snap_suffix = {'Apply-Orbit-File': 'Orb',
                'SAR-Simulation': 'Sim',
                'SARSim-Terrain-Correction': 'TC',
                'SliceAssembly': '',
+               'SnaphuExport': 'snaphu',
                'Speckle-Filter': 'SF',
                'Subset': '',
                'Terrain-Correction': 'TC',
                'Terrain-Flattening': 'TF',
                'ThermalNoiseRemoval': 'tnr',
+               'TOPSAR-Split': 'TSS',
+               'TOPSAR-Deburst': 'TSD'
                'Write': ''}
 
 snap = Storage(suffix=snap_suffix)

--- a/pyroSAR/_dev_config.py
+++ b/pyroSAR/_dev_config.py
@@ -108,7 +108,7 @@ snap_suffix = {'Apply-Orbit-File': 'Orb',
                'Terrain-Flattening': 'TF',
                'ThermalNoiseRemoval': 'tnr',
                'TOPSAR-Split': 'TSS',
-               'TOPSAR-Deburst': 'TSD'
+               'TOPSAR-Deburst': 'TSD',
                'Write': ''}
 
 snap = Storage(suffix=snap_suffix)


### PR DESCRIPTION
I've Added the following SNAP elements to the suffix list:
TOPSAR-Split, TOPSAR-Deburst, SnaphuExport, Interferogram, GoldsteinPhaseFiltering, Back-Geocoding

These were missing causing an error when running my snap workflow using pyroSAR



