### PR TITLE
Update snap/util.py to fix export_extra option

### DIFF
--- a/pyroSAR/snap/util.py
+++ b/pyroSAR/snap/util.py
@@ -488,10 +488,10 @@ def geocode(infile, outdir, t_srs=4326, tr=20, polarizations='all', shapefile=No
                    'localIncidenceAngle',
                    'projectedLocalIncidenceAngle',
                    'DEM']
-        write = parse_node('Write')
-        workflow.insert_node(write, before=tc.id, resetSuccessorSource=False)
-        write.parameters['file'] = outname
-        write.parameters['formatName'] = format
+        #write = parse_node('Write')
+        #workflow.insert_node(write, before=tc.id, resetSuccessorSource=False)
+        #write.parameters['file'] = outname
+        #write.parameters['formatName'] = format
         for item in export_extra:
             if item not in options:
                 raise RuntimeError("ID '{}' not valid for argument 'export_extra'".format(item))


### PR DESCRIPTION
The export_extra option seems not to work, commenting the lines fix the problem. I do not know if there is a consequence. The problem seems related to the fact that there is an insert node which add another Terrain-Correction node and in the final list of steps there are two of them in the end. It basically gives a key error when it tries to open another Terrain-Correction step (split_xml function).