### PR TITLE
Search for processed files in the tmpdir 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ dmypy.json
 
 .idea/
 dev_*
+
+# OSX tempfiles
+.DS_Store

--- a/pyroSAR/snap/auxil.py
+++ b/pyroSAR/snap/auxil.py
@@ -374,7 +374,7 @@ def gpt(xmlfile, outdir, groups=None, cleanup=True,
         print('converting to GTiff')
         translateoptions = {'options': ['-q', '-co', 'INTERLEAVE=BAND', '-co', 'TILED=YES'],
                             'format': 'GTiff'}
-        for item in finder(outname, ['*.img'], recursive=False):
+        for item in finder(tmpname, ['*.img'], recursive=False):
             if re.search('ma0_[HV]{2}', item):
                 pol = re.search('[HV]{2}', item).group()
                 name_new = outname.replace(suffix, '{0}_{1}.tif'.format(pol, suffix))


### PR DESCRIPTION
When using `geocode` and specifying a `tmpdir` which is outside of the specified `outdir` the geocoding step fails at the last stage (GeoTIFF creation) as it is looking for the `.img` files within the `outdir` rather than in the `tmpdir` which is where the processed products reside.  

This is a minor fix to ensure we search the correct directory for the processed files.
