### PR TITLE
scene/infile argument in snap.util.geocode

### DIFF
--- a/docs/general/OSV.rst
+++ b/docs/general/OSV.rst
@@ -96,7 +96,7 @@ matching OSV type for processing.
 
     from pyroSAR.snap import geocode
     scene = 'S1A_IW_GRDH_1SDV_20180101T170648_20180101T170713_019964_021FFD_DA78.zip'
-    geocode(scene=scene,
+    geocode(infile=scene,
             outdir='outdir',
             allow_RES_OSV=True)
 


### PR DESCRIPTION
Argument for the scene's path is named different in the geocode functions of snap and gamma