### PR TITLE
[Archive.select] fix scan of processdir

### DIFF
--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -490,7 +490,7 @@ class ID(object):
         """
         if os.path.isdir(outdir):
             # '{}.*tif$'.format(self.outname_base())
-            return len(finder(outdir, [self.outname_base()], regex=True, recursive=recursive)) != 0
+            return len(finder(outdir, [self.outname_base()], regex=True, recursive=recursive)) > 2
         else:
             return False
     


### PR DESCRIPTION
I've adjusted the threshold in `Archive.select` that decides if a scene was already processed or not.

If a scene fails to process, the GPT workflow and the error logfile are still created. I assume it's similar for `gamma.geocode`, where the shell script and the error logfile are created?