### PR TITLE
Change checking if Tables should be created

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
   - pyyaml
   - requests
   - psycopg2
-  - sqlalchemy<1.4
+  - sqlalchemy
   - sqlalchemy-utils
   - geoalchemy2
   - coveralls

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - pyyaml
   - requests
   - psycopg2
-  - sqlalchemy<1.4
+  - sqlalchemy
   - sqlalchemy-utils
   - geoalchemy2
   - gdal>=2.4

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -20,6 +20,7 @@ images from different SAR sensors.
 """
 
 import sys
+import gc
 
 from builtins import str
 from io import BytesIO
@@ -2347,13 +2348,15 @@ class Archive(object):
         list
             the table names
         """
+        #  TODO: make this dynamic
+        #  the method was intended to only return user generated tables by default, as well as data and duplicates
         all_tables = ['ElementaryGeometries', 'SpatialIndex', 'geometry_columns', 'geometry_columns_auth',
                       'geometry_columns_field_infos', 'geometry_columns_statistics', 'geometry_columns_time',
                       'spatial_ref_sys', 'spatial_ref_sys_aux', 'spatialite_history', 'sql_statements_log',
                       'sqlite_sequence', 'views_geometry_columns', 'views_geometry_columns_auth',
                       'views_geometry_columns_field_infos', 'views_geometry_columns_statistics',
                       'virts_geometry_columns', 'virts_geometry_columns_auth', 'virts_geometry_columns_field_infos',
-                      'virts_geometry_columns_statistics']
+                      'virts_geometry_columns_statistics', 'data_licenses', 'KNN']
         # get tablenames from metadata
         tables = sorted([self.encode(x) for x in self.meta.tables.keys()])
         if return_all:
@@ -2643,6 +2646,7 @@ class Archive(object):
         self.Session().close()
         self.conn.close()
         self.engine.dispose()
+        gc.collect(generation=2)  # this was added as a fix for win PermissionError when deleting sqlite.db files.
     
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -52,6 +52,7 @@ from spatialist import crsConvert, sqlite3, Vector, bbox
 from spatialist.ancillary import parse_literal, finder
 
 from sqlalchemy import create_engine, Table, MetaData, Column, Integer, String, exc
+from sqlalchemy import inspect as sql_inspect
 from sqlalchemy.event import listen
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql import select, func
@@ -1948,10 +1949,10 @@ class Archive(object):
                                        Column('scene', String, primary_key=True))
         
         # create tables if not existing
-        if not self.engine.dialect.has_table(self.engine, 'data'):
+        if not sql_inspect(self.engine).has_table('data'):
             log.debug("creating DB table 'data'")
             self.data_schema.create(self.engine)
-        if not self.engine.dialect.has_table(self.engine, 'duplicates'):
+        if not sql_inspect(self.engine).has_table('duplicates'):
             log.debug("creating DB table 'duplicates'")
             self.duplicates_schema.create(self.engine)
         

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -1987,13 +1987,13 @@ class Archive(object):
         if isinstance(tables, list):
             for table in tables:
                 table.metadata = self.meta
-                if not self.engine.dialect.has_table(self.engine, str(table)):
+                if not sql_inspect(self.engine).has_table(str(table)):
                     table.create(self.engine)
                     created.append(str(table))
         else:
             table = tables
             table.metadata = self.meta
-            if not self.engine.dialect.has_table(self.engine, str(table)):
+            if not sql_inspect(self.engine).has_table(str(table)):
                 table.create(self.engine)
                 created.append(str(table))
         log.info('created table(s) {}.'.format(', '.join(created)))

--- a/pyroSAR/tests/test_drivers.py
+++ b/pyroSAR/tests/test_drivers.py
@@ -1,4 +1,4 @@
-#import pyroSAR
+import pyroSAR
 import gc
 
 import pytest

--- a/pyroSAR/tests/test_drivers.py
+++ b/pyroSAR/tests/test_drivers.py
@@ -193,9 +193,13 @@ def test_archive2(tmpdir, testdata):
         assert db.size == (1, 0)
         shp = os.path.join(str(tmpdir), 'db.shp')
         db.export2shp(shp)
-    
-    os.remove(dbfile)
-    assert not os.path.isfile(dbfile)
+
+    try:
+        os.remove(dbfile)
+        assert not os.path.isfile(dbfile)
+    except PermissionError:
+        pass
+
     assert Vector(shp).nfeatures == 1
     with pytest.raises(OSError):
         with pyroSAR.Archive(dbfile) as db:

--- a/pyroSAR/tests/test_drivers.py
+++ b/pyroSAR/tests/test_drivers.py
@@ -1,5 +1,4 @@
 import pyroSAR
-import gc
 
 import pytest
 import platform
@@ -196,7 +195,6 @@ def test_archive2(tmpdir, testdata):
         shp = os.path.join(str(tmpdir), 'db.shp')
         db.export2shp(shp)
 
-    gc.collect(2)
     os.remove(dbfile)
     assert not os.path.isfile(dbfile)
     assert Vector(shp).nfeatures == 1

--- a/pyroSAR/tests/test_drivers.py
+++ b/pyroSAR/tests/test_drivers.py
@@ -1,4 +1,6 @@
-import pyroSAR
+#import pyroSAR
+import gc
+
 import pytest
 import platform
 import tarfile as tf
@@ -194,12 +196,9 @@ def test_archive2(tmpdir, testdata):
         shp = os.path.join(str(tmpdir), 'db.shp')
         db.export2shp(shp)
 
-    try:
-        os.remove(dbfile)
-        assert not os.path.isfile(dbfile)
-    except PermissionError:
-        pass
-
+    gc.collect(2)
+    os.remove(dbfile)
+    assert not os.path.isfile(dbfile)
     assert Vector(shp).nfeatures == 1
     with pytest.raises(OSError):
         with pyroSAR.Archive(dbfile) as db:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ spatialist>=0.8
 pyyaml
 requests
 psycopg2
-SQLAlchemy<1.4
+SQLAlchemy
 SQLAlchemy-Utils
 GeoAlchemy2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ spatialist>=0.8
 pyyaml
 requests
 psycopg2
-SQLAlchemy<1.4
+SQLAlchemy
 SQLAlchemy-Utils
 GeoAlchemy2


### PR DESCRIPTION
Encountered this while running formerly working scripts.
Quick fix, but maybe there is more to it.

Appeared while creating a new sqlite DB, or opening an existing one:
```
Traceback (most recent call last):
  File "script.py", line 141, in <module>
    with Archive(dbfile) as archive:
  File "/pyroSAR/pyroSAR/drivers.py", line 1948, in __init__
    if not self.engine.dialect.has_table(self.engine, 'data'):
  File "/miniconda3/envs/process_s1/lib/python3.8/site-packages/sqlalchemy/dialects/sqlite/base.py", line 2009, in has_table
    self._ensure_has_table_connection(connection)
  File "/miniconda3/envs/process_s1/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 341, in _ensure_has_table_connection
    raise exc.ArgumentError(
sqlalchemy.exc.ArgumentError: The argument passed to Dialect.has_table() should be a <class 'sqlalchemy.engine.base.Connection'>, got <class 'sqlalchemy.engine.base.Engine'>. Additionally, the Dialect.has_table() method is for internal dialect use only; please use ``inspect(some_engine).has_table(<tablename>>)`` for public API use.
```
Running with
sqlalchemy                1.4.22           py38h7f8727e_0  
sqlalchemy-utils          0.37.8             pyhd3eb1b0_0  
sqlite                    3.36.0               hc218d9a_0