### PR TITLE
Fix invalid source bands for calibration node when processing SLC data

### DIFF
--- a/pyroSAR/snap/util.py
+++ b/pyroSAR/snap/util.py
@@ -267,12 +267,7 @@ def geocode(infile, outdir, t_srs=4326, tr=20, polarizations='all', shapefile=No
     bandnames['beta0'] = ['Beta0_' + x for x in polarizations]
     bandnames['gamma0'] = ['Gamma0_' + x for x in polarizations]
     bandnames['sigma0'] = ['Sigma0_' + x for x in polarizations]
-    
-    if process_S1_SLC and swaths is not None:
-        swaths_pols = ['_'.join((s, p)) for s in swaths for p in polarizations]
-        bandnames['int'] = ['Intensity_' + x for x in swaths_pols]
-    else:
-        bandnames['int'] = ['Intensity_' + x for x in polarizations]
+    bandnames['int'] = ['Intensity_' + x for x in polarizations]
     ############################################
     ############################################
     # parse base workflow


### PR DESCRIPTION
Due to the deburst node now being executed _before_ the calibration node, the name of input source bands for the calibration node changed. 