### PR TITLE
all responses should raise exception on HTTP error

### DIFF
--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -904,6 +904,7 @@ def get_egm_lookup(geoid, software):
             remote = 'https://step.esa.int/auxdata/dem/egm96/ww15mgh_b.zip'
             log.info('{} <<-- {}'.format(local, remote))
             r = requests.get(remote)
+            r.raise_for_status()
             with open(local, 'wb') as out:
                 out.write(r.content)
     
@@ -921,6 +922,7 @@ def get_egm_lookup(geoid, software):
             if not os.path.isfile(gtx_local):
                 log.info('{} <<-- {}'.format(gtx_local, gtx_remote))
                 r = requests.get(gtx_remote)
+                r.raise_for_status()
                 with open(gtx_local, 'wb') as out:
                     out.write(r.content)
         else:


### PR DESCRIPTION
I ran into an issue where some scihub maintenance appeared to cause corrupt S1 orbit files to be written to disk. Investigating the problem, I believe the root cause is in most cases the response of HTTP requests is not checked, thus even when an HTTP error is returned by the server the response is still used, despite being invalid.

This PR ensures each place where an HTTP request is made that an exception will be raised if an HTTP error is encountered, rather than silently proceeding.

Please let me know if there are any concerns about this change.