### PR TITLE
drivers.py: Add BEAM_DIMAP handler class for .dim files

### DIFF
--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -219,7 +219,7 @@ class ID(object):
         lines = ['pyroSAR ID object of type {}'.format(self.__class__.__name__)]
         for item in sorted(self.locals):
             value = getattr(self, item)
-            if item == 'projection' and value:
+            if item == 'projection':
                 value = crsConvert(value, 'proj4')
             line = '{0}: {1}'.format(item, value)
             lines.append(line)
@@ -408,6 +408,7 @@ class ID(object):
             raise RuntimeError('file type not supported')
         
         meta = {}
+
         ext_lookup = {'.N1': 'ASAR', '.E1': 'ERS1', '.E2': 'ERS2'}
         extension = os.path.splitext(header)[1]
         if extension in ext_lookup:


### PR DESCRIPTION
This adds a new Handler class to handle `.dim` files which are used by SNAP software.

Fixes #176.

Things to note:

- getCorners() may not be needed under `BEAM_DIMAP` because I extracted the `meta['corners']` data from `gdalinfo` from the raster data. Or perhaps I should still include this under `BEAM_DIMAP.getCorners()`?
- Only tested with Sentinel-1 data (I don't have access to other sensors)
- Added flexibility for datasets with no CRS data.
- Tries to get all available metadata from the .dim first before loading the raster in GDAL.

Here is the sample output when using a terrain corrected .dim file with `from pyroSAR import identify`:

```
pyroSAR ID object of type BEAM_DIMAP
acquisition_mode: IW
cycleNumber: 113
frameNumber:
lines: 3176
orbit: ASCENDING
orbitNumber_abs: 17393
orbitNumber_rel: 171
polarizations: ['VV']
product: Sentinel-1 IW Level-1 SLC Product
projection: +proj=longlat +ellps=WGS84 +no_defs
samples: 2771
sensor: SENTINEL-1A
spacing: (0.0003772924193301991, -0.0003772924193301991)
start: 09-JUL-2017 11:24:23.927343
stop: 09-JUL-2017 11:24:40.803460
```

Let me know what you think @johntruckenbrodt. Hopefully I got the structure of your software right.

