### PR TITLE
Travis CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,7 @@ before_install:
 
 install:
   - mkdir ~/.cache/pip/wheels # remove warning "Url 'file:///home/travis/.cache/pip/wheels' is ignored: it is neither a file nor a directory."
-  - pip install --ignore-installed six certifi # install packages inside the venv if the system version is too old
-  - pip install --ignore-installed distutils2 # deprecated, but dedicated installation needed for cffi
+  - pip install --ignore-installed setuptools pip six certifi # install packages inside the venv if the system version is too old
   - pip install numpy
   - pip install GDAL==$(gdal-config --version) --global-option=build_ext --global-option="$(gdal-config --cflags)"
   - pip install -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
     - TESTDATA_DIR=$HOME/testdata
     - PGUSER=travis
-    - PGPORT=5433
     - PGPASSWORD=Password12!
     - SNAP_VERSION=8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ addons:
       - libproj-dev
       - python3-dev
       - postgresql-14-postgis-3
+      - libffi-dev
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
 install:
   - mkdir ~/.cache/pip/wheels # remove warning "Url 'file:///home/travis/.cache/pip/wheels' is ignored: it is neither a file nor a directory."
   - pip install --ignore-installed six certifi # install packages inside the venv if the system version is too old
-  - pip install --ignore-installed distutils # deprecated, but dedicated installation needed for cffi
+  - pip install --ignore-installed distutils2 # deprecated, but dedicated installation needed for cffi
   - pip install numpy
   - pip install GDAL==$(gdal-config --version) --global-option=build_ext --global-option="$(gdal-config --cflags)"
   - pip install -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ addons:
       - libproj-dev
       - python3-dev
       - postgresql-14-postgis-3
-      - libffi-dev
 
 services:
   - postgresql
@@ -44,6 +43,7 @@ before_install:
 install:
   - mkdir ~/.cache/pip/wheels # remove warning "Url 'file:///home/travis/.cache/pip/wheels' is ignored: it is neither a file nor a directory."
   - pip install --ignore-installed six certifi # install packages inside the venv if the system version is too old
+  - pip install --ignore-installed distutils # deprecated, but dedicated installation needed for cffi
   - pip install numpy
   - pip install GDAL==$(gdal-config --version) --global-option=build_ext --global-option="$(gdal-config --cflags)"
   - pip install -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_install:
   - export PATH=$PATH:/opt/snap/bin
 
 install:
+  - mkdir ~/.cache/pip/wheels # remove warning "Url 'file:///home/travis/.cache/pip/wheels' is ignored: it is neither a file nor a directory."
   - pip install --ignore-installed six certifi # install packages inside the venv if the system version is too old
   - pip install numpy
   - pip install GDAL==$(gdal-config --version) --global-option=build_ext --global-option="$(gdal-config --cflags)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - SNAP_VERSION=8
 
 addons:
-  postgresql: '12'
+  postgresql: '14'
   apt:
     sources:
       - sourceline: 'ppa:ubuntugis/ppa'
@@ -26,7 +26,7 @@ addons:
       - libsqlite3-mod-spatialite
       - libproj-dev
       - python3-dev
-      - postgresql-12-postgis-3
+      - postgresql-14-postgis-3
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: focal
+dist: jammy
 language: python
 sudo: required
 cache:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 import os
 
 # Create .pyrosar in HOME - Directory
@@ -11,7 +11,7 @@ with open(os.path.join(directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='pyroSAR',
-      packages=find_packages(),
+      packages=find_namespace_packages(),
       include_package_data=True,
       python_requires='>=3',
       setup_requires=['setuptools_scm'],


### PR DESCRIPTION
Several changes to fix and clean up Travis CI builds:
- use `setuptools.find_namespace_packages` instead of `setuptools.find_packages` to ensure future inclusion of data packages
- use Ubuntu 22.04
- use PostgreSQL 14 and remove explicit PGPORT definition
- upgrade setuptools and pip into venv