### PR TITLE
Archive.select: new option for acquisition time filtering

### DIFF
--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -622,7 +622,7 @@ class DEMHandler:
                               'vsi': '/vsizip/',
                               'pattern': {'dem': '*.hgt'}
                               },
-            'SRTM 3Sec': {'url': 'https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF',
+            'SRTM 3Sec': {'url': 'https://download.esa.int/step/auxdata/dem/SRTM90/tiff',
                           'nodata': -32768.0,
                           'vsi': '/vsizip/',
                           'pattern': {'dem': 'srtm*.tif'}

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -68,7 +68,6 @@ import socket
 import time
 import platform
 import subprocess
-import json
 import logging
 
 log = logging.getLogger(__name__)
@@ -133,7 +132,7 @@ def identify_many(scenes, pbar=False, sortkey=None):
 
     Parameters
     ----------
-    scenes: list[str]
+    scenes: list[str or ID]
         the file names of the scenes to be identified
     pbar: bool
         adds a progressbar if True

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -382,7 +382,7 @@ class ID(object):
         
         try:
             files = finder(target=self.scene, matchlist=[pattern],
-                       foldermode=foldermode, regex=True)
+                           foldermode=foldermode, regex=True)
         except RuntimeError:
             # Return the scene if only a file and not zip
             return self.scene
@@ -407,7 +407,7 @@ class ID(object):
         # If only one file return the file in array
         if isinstance(files, str):
             files = [files]
-
+        
         if len(files) == 1:
             prefix = {'zip': '/vsizip/', 'tar': '/vsitar/', None: ''}[self.compression]
             header = files[0]
@@ -1544,22 +1544,30 @@ class ESA(ID):
             raise RuntimeError('product level 0 not supported (yet)')
         
         self.meta = self.scanMetadata()
-
+        
         corners = self.getCorners()
-        self.meta['coordinates'] = [tuple([corners['xmin'], corners['ymin']]),tuple([corners['xmin'], corners['ymax']]),
-                                    tuple([corners['xmax'], corners['ymin']]),tuple([corners['xmax'], corners['ymax']])]
+        self.meta['coordinates'] = [tuple([corners['xmin'], corners['ymin']]),
+                                    tuple([corners['xmin'], corners['ymax']]),
+                                    tuple([corners['xmax'], corners['ymin']]),
+                                    tuple([corners['xmax'], corners['ymax']])]
         self.meta['acquisition_mode'] = match2.group('image_mode')
         self.meta['product'] = 'SLC' if self.meta['acquisition_mode'] in ['IMS', 'APS', 'WSS'] else 'PRI'
         self.meta['frameNumber'] = int(match.group('counter'))
-
-        if self.meta['acquisition_mode'] == 'IMS' or self.meta['acquisition_mode'] == 'APS' or self.meta['acquisition_mode'] == 'WSM':
-            self.meta['image_geometry'] = 'SLANT_RANGE' 
+        
+        if self.meta['acquisition_mode'] == 'IMS' \
+                or self.meta['acquisition_mode'] == 'APS' \
+                or self.meta['acquisition_mode'] == 'WSM':
+            self.meta['image_geometry'] = 'SLANT_RANGE'
         elif self.meta['acquisition_mode'] == 'IMP' or self.meta['acquisition_mode'] == 'APP':
             self.meta['image_geometry'] = 'GROUND_RANGE'
         else:
             raise RuntimeError("unsupported adquisition mode: {}".format(self.meta['acquisition_mode']))
-       
-        self.meta['incidenceAngleMin'], self.meta['incidenceAngleMax'], self.meta['rangeResolution'], self.meta['azimuthResolution'], self.meta['neszNear'], self.meta['neszFar']  = get_angles_resolution(self.meta['sensor'], self.meta['acquisition_mode'], self.meta['SPH_SWATH'], self.meta['start'])
+        
+        self.meta['incidenceAngleMin'], self.meta['incidenceAngleMax'], \
+        self.meta['rangeResolution'], self.meta['azimuthResolution'], \
+        self.meta['neszNear'], self.meta['neszFar'] = \
+            get_angles_resolution(self.meta['sensor'], self.meta['acquisition_mode'],
+                                  self.meta['SPH_SWATH'], self.meta['start'])
         self.meta['incidence'] = median([self.meta['incidenceAngleMin'], self.meta['incidenceAngleMax']])
         # register the standardized meta attributes as object attributes
         super(ESA, self).__init__(self.meta)
@@ -1968,15 +1976,15 @@ class TSX(ID):
     def __init__(self, scene):
         if isinstance(scene, str):
             self.scene = os.path.realpath(scene)
-        
+            
             self.pattern = r'^(?P<sat>T[DS]X1)_SAR__' \
-                        r'(?P<prod>SSC|MGD|GEC|EEC)_' \
-                        r'(?P<var>____|SE__|RE__|MON1|MON2|BTX1|BRX2)_' \
-                        r'(?P<mode>SM|SL|HS|HS300|ST|SC)_' \
-                        r'(?P<pols>[SDTQ])_' \
-                        r'(?:SRA|DRA)_' \
-                        r'(?P<start>[0-9]{8}T[0-9]{6})_' \
-                        r'(?P<stop>[0-9]{8}T[0-9]{6})(?:\.xml|)$'
+                           r'(?P<prod>SSC|MGD|GEC|EEC)_' \
+                           r'(?P<var>____|SE__|RE__|MON1|MON2|BTX1|BRX2)_' \
+                           r'(?P<mode>SM|SL|HS|HS300|ST|SC)_' \
+                           r'(?P<pols>[SDTQ])_' \
+                           r'(?:SRA|DRA)_' \
+                           r'(?P<start>[0-9]{8}T[0-9]{6})_' \
+                           r'(?P<stop>[0-9]{8}T[0-9]{6})(?:\.xml|)$'
             
             self.pattern_ds = r'^IMAGE_(?P<pol>HH|HV|VH|VV)_(?:SRA|FWD|AFT)_(?P<beam>[^\.]+)\.(cos|tif)$'
             self.examine(include_folders=False)
@@ -1986,7 +1994,7 @@ class TSX(ID):
             
             self.meta = self.scanMetadata()
             self.meta['projection'] = crsConvert(4326, 'wkt')
-            
+        
         super(TSX, self).__init__(self.meta)
     
     def getCorners(self):
@@ -1996,7 +2004,7 @@ class TSX(ID):
         lat = [float(x.find('lat').text) for x in pts]
         lon = [float(x.find('lon').text) for x in pts]
         # shift lon in case of west direction.
-        lon = [x-360 if x > 180 else x for x in lon ]
+        lon = [x - 360 if x > 180 else x for x in lon]
         return {'xmin': min(lon), 'xmax': max(lon), 'ymin': min(lat), 'ymax': max(lat)}
     
     def scanMetadata(self):
@@ -2104,9 +2112,8 @@ class TDM(TSX):
         lat = [float(x.find('lat').text) for x in pts]
         lon = [float(x.find('lon').text) for x in pts]
         # shift lon in case of west direction.
-        lon = [x-360 if x > 180 else x for x in lon ]
+        lon = [x - 360 if x > 180 else x for x in lon]
         return {'xmin': min(lon), 'xmax': max(lon), 'ymin': min(lat), 'ymax': max(lat)}
-    
     
     def scanMetadata(self):
         annotation = self.getFileObj(self.file).getvalue()
@@ -2118,15 +2125,17 @@ class TDM(TSX):
         meta['SAT1'] = tree.find('.//commonAcquisitionInfo/satelliteIDsat1', namespaces).text
         meta['SAT2'] = tree.find('.//commonAcquisitionInfo/satelliteIDsat2', namespaces).text
         meta['inSARmasterID'] = tree.find('.//commonAcquisitionInfo/inSARmasterID', namespaces).text
-        meta['inSARmaster'] = tree.find('.//commonAcquisitionInfo/satelliteID{}'.format(meta['inSARmasterID'].lower()), namespaces).text.replace('-', '')
-
-        meta['acquisitionItemID'] = int(tree.find('.//commonAcquisitionInfo/operationsInfo/acquisitionItemID', namespaces).text)
+        pattern = './/commonAcquisitionInfo/satelliteID{}'.format(meta['inSARmasterID'].lower())
+        meta['inSARmaster'] = tree.find(pattern, namespaces).text.replace('-', '')
+        
+        pattern = './/commonAcquisitionInfo/operationsInfo/acquisitionItemID'
+        meta['acquisitionItemID'] = int(tree.find(pattern, namespaces).text)
         
         meta['effectiveBaseline'] = float(tree.find('.//acquisitionGeometry/effectiveBaseline', namespaces).text)
         meta['heightOfAmbiguity'] = float(tree.find('.//acquisitionGeometry/heightOfAmbiguity', namespaces).text)
         meta['distanceActivePos'] = float(tree.find('.//acquisitionGeometry/distanceActivePos', namespaces).text)
         meta['distanceTracks'] = float(tree.find('.//acquisitionGeometry/distanceTracks', namespaces).text)
-    
+        
         meta['cooperativeMode'] = tree.find('.//commonAcquisitionInfo/cooperativeMode', namespaces).text
         
         if meta['cooperativeMode'].lower() == "bistatic":
@@ -2134,18 +2143,15 @@ class TDM(TSX):
         else:
             meta['bistatic'] = False
         
-
         meta['orbit'] = tree.find('.//acquisitionGeometry/orbitDirection', namespaces).text[0]
-        
-        
 
-        self.primary_scene = os.path.join(self.scene, tree.findall(".//productComponents/component[@componentClass='imageData']/file/location/name", )[0].text)
-        self.secondary_scene = os.path.join(self.scene, tree.findall(".//productComponents/component[@componentClass='imageData']/file/location/name", )[1].text)
+        pattern = ".//productComponents/component[@componentClass='imageData']/file/location/name"
+        elements = tree.findall(pattern, )
+        self.primary_scene = os.path.join(self.scene, elements[0].text)
+        self.secondary_scene = os.path.join(self.scene, elements[1].text)
         meta["SAT1"] = TSX(self.primary_scene).scanMetadata()
         meta["SAT2"] = TSX(self.secondary_scene).scanMetadata()
         
-        
-                
         meta['start'] = self.parse_date(tree.find('.//orbitHeader/firstStateTime/firstStateTimeUTC', namespaces).text)
         meta['stop'] = self.parse_date(tree.find('.//orbitHeader/lastStateTime/lastStateTimeUTC', namespaces).text)
         meta['samples'] = int(tree.find('.//coregistration/coregRaster/samples', namespaces).text)
@@ -2155,14 +2161,13 @@ class TDM(TSX):
         meta['looks'] = (rlks, azlks)
         meta['incidence'] = float(tree.find('.//commonSceneInfo/sceneCenterCoord/incidenceAngle', namespaces).text)
         
-        
         meta['orbit'] = meta[meta['inSARmasterID']]['orbit']
         meta['polarizations'] = meta[meta['inSARmasterID']]['polarizations']
         
         meta['orbitNumber_abs'] = meta[meta['inSARmasterID']]['orbitNumber_abs']
         meta['orbitNumber_rel'] = meta[meta['inSARmasterID']]['orbitNumber_rel']
         meta['cycleNumber'] = meta[meta['inSARmasterID']]['cycleNumber']
-        meta['frameNumber'] = meta[meta['inSARmasterID']]['frameNumber'] 
+        meta['frameNumber'] = meta[meta['inSARmasterID']]['frameNumber']
         
         meta['acquisition_mode'] = meta[meta['inSARmasterID']]['acquisition_mode']
         meta['start'] = meta[meta['inSARmasterID']]['start']
@@ -2170,12 +2175,12 @@ class TDM(TSX):
         meta['spacing'] = meta[meta['inSARmasterID']]['spacing']
         meta['samples'] = meta[meta['inSARmasterID']]['samples']
         meta['lines'] = meta[meta['inSARmasterID']]['lines']
-        meta['looks'] = meta[meta['inSARmasterID']]['looks'] 
+        meta['looks'] = meta[meta['inSARmasterID']]['looks']
         meta['incidence'] = meta[meta['inSARmasterID']]['incidence']
         
         return meta
-    
-    
+
+
 class Archive(object):
     """
     Utility for storing SAR image metadata in a database


### PR DESCRIPTION
With the new argument `date_strict`, the time filtering arguments `mindate` and `maxdate` can now be treated less strict:
- strict: start >= `mindate` & stop <= `maxdate`
- not strict: stop >= `mindate` & start <= `maxdate`