### PR TITLE
GAMMA handling improvements

### DIFF
--- a/environment-doc.yml
+++ b/environment-doc.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - matplotlib
   - numpy
-  - sphinx
+  - sphinx<7.0  # https://github.com/readthedocs/sphinx_rtd_theme/issues/1463
   - sphinxcontrib-bibtex>=2.2
   - pip
   - cairosvg

--- a/pyroSAR/examine.py
+++ b/pyroSAR/examine.py
@@ -1,6 +1,6 @@
 ###############################################################################
 # Examination of SAR processing software
-# Copyright (c) 2019-2021, the pyroSAR Developers.
+# Copyright (c) 2019-2023, the pyroSAR Developers.
 
 # This file is part of the pyroSAR Project. It is subject to the
 # license terms in the LICENSE.txt file found in the top-level

--- a/pyroSAR/examine.py
+++ b/pyroSAR/examine.py
@@ -16,12 +16,13 @@ import os
 import shutil
 import platform
 import re
+import subprocess
 import warnings
 import subprocess as sp
 import pkg_resources
 
 from pyroSAR._dev_config import ConfigHandler
-from spatialist.ancillary import finder
+from spatialist.ancillary import finder, run
 
 import logging
 
@@ -395,12 +396,12 @@ class ExamineGamma(object):
         self.version = re.search('GAMMA_SOFTWARE-(?P<version>[0-9]{8})',
                                  getattr(self, 'home')).group('version')
         
-        if not hasattr(self, 'gdal_config'):
-            gdal_config = '/usr/bin/gdal-config'
-            if not os.path.isfile(gdal_config):
-                warnings.warn('could not find GDAL system installation under {}\n'
-                              'please modify the pyroSAR configuration: {}'.format(gdal_config, self.fname))
+        try:
+            out, err = run(['which', 'gdal-config'], void=False)
+            gdal_config = out.strip('\n')
             self.gdal_config = gdal_config
+        except subprocess.CalledProcessError:
+            raise RuntimeError('could not find command gdal-config.')
         self.__update_config()
     
     def __read_config(self):
@@ -414,7 +415,7 @@ class ExamineGamma(object):
         if 'GAMMA' not in config.sections:
             config.add_section('GAMMA')
         
-        for attr in ['home', 'version', 'gdal_config']:
+        for attr in ['home', 'version']:
             self.__update_config_attr(attr, getattr(self, attr), 'GAMMA')
     
     @staticmethod

--- a/pyroSAR/gamma/auxil.py
+++ b/pyroSAR/gamma/auxil.py
@@ -407,12 +407,32 @@ class Namespace(object):
         return '-'
     
     def appreciate(self, keys):
+        """
+        
+        Parameters
+        ----------
+        keys: list[str]
+
+        Returns
+        -------
+
+        """
         for key in keys:
             setattr(self, key.replace('.', '_'), os.path.join(self.__outdir, self.__base + '_' + key))
             if key not in self.__reg:
                 self.__reg.append(key.replace('.', '_'))
     
     def depreciate(self, keys):
+        """
+        
+        Parameters
+        ----------
+        keys: list[str]
+
+        Returns
+        -------
+
+        """
         for key in keys:
             setattr(self, key.replace('.', '_'), '-')
             if key not in self.__reg:
@@ -478,7 +498,7 @@ def do_execute(par, ids, exist_ok):
     ----------
     par: dict
         a dictionary containing all arguments for the command
-    ids: list
+    ids: list[str]
         the IDs of the output files
     exist_ok: bool
         allow existing output files?

--- a/pyroSAR/gamma/util.py
+++ b/pyroSAR/gamma/util.py
@@ -155,7 +155,7 @@ def convert2gamma(id, directory, S1_tnr=True, S1_bnr=True,
     S1_bnr: bool
         only Sentinel-1 GRD: should border noise removal be applied to the image?
         This is available since version 20191203, for older versions this argument is ignored.
-    basename_extensions: list of str
+    basename_extensions: list[str] or None
         names of additional parameters to append to the basename, e.g. ['orbitNumber_rel']
     exist_ok: bool
         allow existing output files and do not create new ones?
@@ -166,11 +166,11 @@ def convert2gamma(id, directory, S1_tnr=True, S1_bnr=True,
     outdir: str or None
         the directory to execute the command in
     shellscript: str or None
-        a file to write the GAMMA commands to in shell format
+        a file to write the GAMMA commands to in bash format
 
     Returns
     -------
-    list or None
+    list[str] or None
         the sorted image file names if ``return_fnames=True`` and None otherwise
     """
     
@@ -372,6 +372,12 @@ def convert2gamma(id, directory, S1_tnr=True, S1_bnr=True,
                         pars['edge_flag'] = 2
                     else:
                         pars['edge_flag'] = 0
+                else:
+                    if S1_bnr:
+                        raise RuntimeError("The command par_S1_GRD of this GAMMA "
+                                           "version does not support border noise "
+                                           "removal. You may want to consider "
+                                           "pyroSAR's own method for this task.")
                 pars['MLI'] = outname
                 pars['MLI_par'] = outname + '.par'
                 if do_execute(pars, ['MLI', 'MLI_par'], exist_ok):
@@ -636,12 +642,12 @@ def geocode(scene, dem, tmpdir, outdir, spacing, scaling='linear', func_geoback=
     
     - images in map geometry
     
-      * **dem_seg_geo**: dem subsetted to the extent of the intersect between input DEM and SAR image
+      * **dem_seg_geo**: dem subsetted to the extent of the intersection between input DEM and SAR image
       * (**u_geo**): zenith angle of surface normal vector n (angle between z and n)
       * (**v_geo**): orientation angle of n (between x and projection of n in xy plane)
       * **inc_geo**: local incidence angle (between surface normal and look vector)
       * (**psi_geo**): projection angle (between surface normal and image plane normal)
-      * **ls_map_geo**: layover and shadow map (in map projection)
+      * **ls_map_geo**: layover and shadow map
       * (**sim_sar_geo**): simulated SAR backscatter image
       * (**pix_ellip_sigma0_geo**): ellipsoid-based pixel area
       * (**pix_area_sigma0_geo**): illuminated area as obtained from integrating DEM-facets in sigma projection (command pixel_area)
@@ -1068,7 +1074,7 @@ def multilook(infile, outfile, spacing, rlks=None, azlks=None,
 
     Parameters
     ----------
-    infile: str or list
+    infile: str or list[str]
         one of the following:
         
         - a SAR image in GAMMA format with a parameter file <infile>.par

--- a/pyroSAR/gamma/util.py
+++ b/pyroSAR/gamma/util.py
@@ -1158,7 +1158,10 @@ def multilook(infile, outfile, spacing, rlks=None, azlks=None,
                         tab.write(' '.join(item) + '\n')
             pars['SLC_tab'] = slc_tab
             if do_execute(pars, ['MLI', 'MLI_par'], exist_ok):
-                isp.multi_look_ScanSAR(**pars)
+                if 'multi_look_ScanSAR' in dir(isp):
+                    isp.multi_look_ScanSAR(**pars)
+                else:
+                    isp.multi_S1_TOPS(**pars)
                 par2hdr(outfile + '.par', outfile + '.hdr')
     else:
         # multilooking of MLI images


### PR DESCRIPTION
This enhances the usability of the `gamma` module:
- the `LAT` module is no longer needed: new pyroSAR-internal implementations can be used if the module is missing (concerns commands `product`, `ratio` and `linear_to_dB`)
- improved backwards compatibility: two cases have been added in which pyroSAR uses the newest command if available and falls back to an older alternative if not (`multi_look_ScanSAR`->`multi_S1_TOPS`, `gc_map2` -> `gc_map`)
- various bug fixes and documentation imrprovements