### PR TITLE
Update parameter name `tr` to `spacing`

### DIFF
--- a/pyroSAR/snap/util.py
+++ b/pyroSAR/snap/util.py
@@ -224,7 +224,7 @@ def geocode(infile, outdir, t_srs=4326, spacing=20, polarizations='all', shapefi
 
     >>> from pyroSAR.snap import geocode
     >>> filename = 'S1A_IW_GRDH_1SDV_20180829T170656_20180829T170721_023464_028DE0_F7BD.zip'
-    >>> geocode(infile=filename, outdir='outdir', tr=20, scaling='dB',
+    >>> geocode(infile=filename, outdir='outdir', spacing=20, scaling='dB',
     >>>         export_extra=['DEM', 'localIncidenceAngle'], t_srs=4326)
 
     See Also


### PR DESCRIPTION
Just stumbled across this little leftover mention of `tr` when I was following the example given for the `geocode` (SNAP) function, which lead to this error:

```
Traceback (most recent call last): 
    File "snap_pipeline.py", line 5, in <module>
        geocode(infile=filename, outdir='/mnt/u/bremen/users/bahl_jo/S1/NorthGreenland/stack_1/stack_1_A', tr=40, scaling='dB', export_extra=['DEM'], t_srs=4326)
TypeError: geocode() got an unexpected keyword argument 'tr'  
```

the parameter should be called `spacing`, I believe.