### PR TITLE
`DEMHandler.__get_resolution` allow southern hemisphere latitude values

### DIFF
--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -631,7 +631,7 @@ class DEMHandler:
         """
         for key, val in self.config[dem_type]['resolution'].items():
             ymin, ymax = [int(y) for y in key.split('-')]
-            if ymin <= y <= ymax:
+            if ymin <= abs(y) <= ymax:
                 return val
     
     @staticmethod


### PR DESCRIPTION
Noticed this while processing a scene in the southern hemisphere with [S1_NRB](https://github.com/SAR-ARD/S1_NRB). 

`DEMHandler.__get_resolution` returned `None` as it got a negative latitude value and then caused the following error in `DEMHandler.load`:

```
[1/3] /Users/marcowo/.snap/auxdata/dem/Copernicus 30m Global DEM/Copernicus_DSM_COG_10_S13_00_E048_00_DEM.tif <<-- https://copernicus-dem-30m.s3.eu-central-1.amazonaws.com/Copernicus_DSM_COG_10_S13_00_E048_00_DEM/Copernicus_DSM_COG_10_S13_00_E048_00_DEM.tif
[2/3] /Users/marcowo/.snap/auxdata/dem/Copernicus 30m Global DEM/Copernicus_DSM_COG_10_S11_00_E047_00_DEM.tif <<-- https://copernicus-dem-30m.s3.eu-central-1.amazonaws.com/Copernicus_DSM_COG_10_S11_00_E047_00_DEM/Copernicus_DSM_COG_10_S11_00_E047_00_DEM.tif
[3/3] /Users/marcowo/.snap/auxdata/dem/Copernicus 30m Global DEM/Copernicus_DSM_COG_10_S12_00_E047_00_DEM.tif <<-- https://copernicus-dem-30m.s3.eu-central-1.amazonaws.com/Copernicus_DSM_COG_10_S12_00_E047_00_DEM/Copernicus_DSM_COG_10_S12_00_E047_00_DEM.tif
Traceback (most recent call last):
  File "/Users/marcowo/mambaforge/envs/nrb_env_dev/lib/python3.9/site-packages/IPython/core/interactiveshell.py", line 3508, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-2-5cad159f2f6c>", line 9, in <module>
    S1_NRB.process(config_file=config_file, section_name=section, debug=debug)
  File "/Users/marcowo/Documents/pypypy/S1_NRB/S1_NRB/processor.py", line 191, in main
    dem.mosaic(geometry=geom, outname=fname_dem, dem_type=config['dem_type'],
  File "/Users/marcowo/Documents/pypypy/S1_NRB/S1_NRB/dem.py", line 302, in mosaic
    dem_autoload([geometry], demType=dem_type,
  File "/Users/marcowo/mambaforge/envs/nrb_env_dev/lib/python3.9/site-packages/pyroSAR/auxdata.py", line 238, in dem_autoload
    return handler.load(dem_type=demType,
  File "/Users/marcowo/mambaforge/envs/nrb_env_dev/lib/python3.9/site-packages/pyroSAR/auxdata.py", line 1099, in load
    shift_x = res[0] / 2
TypeError: 'NoneType' object is not subscriptable
```

This seemed rather straightforward, but I hope I didn't miss anything.