### PR TITLE
Updates to the writer and erode_edges functions

### DIFF
--- a/pyroSAR/snap/auxil.py
+++ b/pyroSAR/snap/auxil.py
@@ -471,8 +471,8 @@ def writer(xmlfile, outdir, basename_extensions=None,
         log.info(message.format('cleaning image edges and ' if clean_edges else ''))
         translateoptions = {'options': ['-q', '-co', 'INTERLEAVE=BAND', '-co', 'TILED=YES'],
                             'format': 'GTiff'}
-        
-        erode_edges(src=src, only_boundary=True, pixels=clean_edges_npixels)
+        if clean_edges:
+            erode_edges(src=src, only_boundary=True, pixels=clean_edges_npixels)
         
         if src_format == 'BEAM-DIMAP':
             src = src.replace('.dim', '.data')

--- a/pyroSAR/snap/auxil.py
+++ b/pyroSAR/snap/auxil.py
@@ -1535,7 +1535,7 @@ def erode_edges(src, only_boundary=False, connectedness=4, pixels=1):
         return array, mask
     
     # make sure a backscatter image is used for creating the mask
-    backscatter = [x for x in images if re.search('^(?:Sig|Gam)ma0_', os.path.basename(x))]
+    backscatter = [x for x in images if re.search('^(?:Sigma0_|Gamma0_|C11|C22)', os.path.basename(x))]
     images.insert(0, images.pop(images.index(backscatter[0])))
     
     mask = None


### PR DESCRIPTION
It's quite a small pull request:
- I  added an if statement in the writer mode containing the clean_edges bool, which was not used to decide whether to call for erode_edges.
- I added C11.img and C22.img as acceptable backscatter images for creating the mask with erode_edges. Otherwise, it was not possible to clean edges when working with C2 polarimetric matrices.

If you think it would bring something positive, I can also add the workflow I've been using to go from Sentinel 1 SLC data to geocoded C2 polarimetric matrices!