### PR TITLE
enable identify on TDM scenes

### DIFF
--- a/docs/source/api/drivers.rst
+++ b/docs/source/api/drivers.rst
@@ -19,6 +19,7 @@ Drivers
         ESA
         SAFE
         TSX
+        TDM
         Archive
 
     .. rubric:: functions

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -117,7 +117,13 @@ def identify(scene):
     if not os.path.exists(scene):
         raise OSError("No such file or directory: '{}'".format(scene))
     
-    for handler in ID.__subclasses__():
+    def get_subclasses(c):
+        subclasses = c.__subclasses__()
+        for subclass in subclasses.copy():
+            subclasses.extend(get_subclasses(subclass))
+        return list(set(subclasses))
+    
+    for handler in get_subclasses(ID):
         try:
             return handler(scene)
         except (RuntimeError, KeyError, AttributeError):


### PR DESCRIPTION
The function [pyroSAR.drivers.identify](https://pyrosar.readthedocs.io/en/latest/api/drivers.html#pyroSAR.drivers.identify) could only identify scenes whose driver is a direct subclass of class [ID](https://pyrosar.readthedocs.io/en/latest/api/drivers.html#pyroSAR.drivers.ID). This did not work for [TDM](https://pyrosar.readthedocs.io/en/latest/api/drivers.html#pyroSAR.drivers.TDM), which is a subclass of [TSX](https://pyrosar.readthedocs.io/en/latest/api/drivers.html#pyroSAR.drivers.TSX). Now the list of `ID` subclasses is recursively scanned for all further nested subclasses.