### PR TITLE
Adapt ExamineGamma for different installs

### DIFF
--- a/docs/source/general/installation.rst
+++ b/docs/source/general/installation.rst
@@ -130,3 +130,8 @@ To test `pysqlite2` you can import it as follows and then run the test above:
 
 Installing this package is likely to cause problems with the `sqlite3` library installed on the system.
 Thus, it is safer to build a static `sqlite3` library for it (see installation script).
+
+GAMMA
+-----
+GAMMA's home directory as environment variable 'GAMMA_HOME' is expected to end either as GAMMA_SOFTWARE-<VERSIONNUMBER> or GAMMA_SOFTWARE/<VERSIONNUMBER>. 
+If this differs in your install and cannot be changed, a workaround is adjusting the expected pattern in :class:`~pyroSAR.examine.ExamineGamma`.

--- a/pyroSAR/examine.py
+++ b/pyroSAR/examine.py
@@ -393,7 +393,7 @@ class ExamineGamma(object):
                 setattr(self, 'home', home_sys)
             else:
                 raise RuntimeError('could not read GAMMA installation directory')
-        self.version = re.search('GAMMA_SOFTWARE-(?P<version>[0-9]{8})',
+        self.version = re.search('GAMMA_SOFTWARE/(?P<version>[0-9]{8})',
                                  getattr(self, 'home')).group('version')
         
         try:

--- a/pyroSAR/examine.py
+++ b/pyroSAR/examine.py
@@ -393,7 +393,7 @@ class ExamineGamma(object):
                 setattr(self, 'home', home_sys)
             else:
                 raise RuntimeError('could not read GAMMA installation directory')
-        self.version = re.search('GAMMA_SOFTWARE/(?P<version>[0-9]{8})',
+        self.version = re.search('GAMMA_SOFTWARE[-/](?P<version>[0-9]{8})',
                                  getattr(self, 'home')).group('version')
         
         try:


### PR DESCRIPTION
This is a current fix for me, but the home directory of GAMMA might be different on other machines as well:
trying to get the version expects the pattern GAMMA_SOFTWARE-<VERSION>, which did not match the path on my install (/apps/GAMMA_SOFTWARE/VERSION), so the call returned an error when calling GAMMA functions via pyroSAR.
Maybe a hint could be added to a how to install with GAMMA if the home directory differs from this expected pattern.


