### PR TITLE
outsourced product regex patterns into new dedicated module 'patterns'

### DIFF
--- a/pyroSAR/_dev_config.py
+++ b/pyroSAR/_dev_config.py
@@ -2,7 +2,7 @@
 ###############################################################################
 # pyroSAR configuration handling
 
-# Copyright (c) 2018-2021, the pyroSAR Developers.
+# Copyright (c) 2018-2023, the pyroSAR Developers.
 
 # This file is part of the pyroSAR Project. It is subject to the
 # license terms in the LICENSE.txt file found in the top-level
@@ -19,19 +19,6 @@ import configparser as ConfigParser
 
 __LOCAL__ = ['sensor', 'projection', 'orbit', 'polarizations', 'acquisition_mode',
              'start', 'stop', 'product', 'spacing', 'samples', 'lines']
-
-# a pattern to search for pyroSAR processing products and extract metadata attributes from the file name
-product_pattern = r'(?:.*[/\\]|)' \
-                  r'(?P<outname_base>' \
-                  r'(?P<sensor>[A-Z0-9]{1,4})_+' \
-                  r'(?P<acquisition_mode>[A-Z0-9]{1,4})_+' \
-                  r'(?P<orbit>[AD])_' \
-                  r'(?P<start>[0-9T]{15})' \
-                  r'(?:_(?P<extensions>\w*?)|)' \
-                  r')_*' \
-                  r'(?:(?P<polarization>[HV]{2})_' \
-                  r'(?P<proc_steps>[\w-]*)|)' \
-                  r'(?P<filetype>(?:.tif|.nc|))$'
 
 
 class Storage(dict):

--- a/pyroSAR/ancillary.py
+++ b/pyroSAR/ancillary.py
@@ -1,7 +1,7 @@
 ###############################################################################
 # ancillary routines for software pyroSAR
 
-# Copyright (c) 2014-2022, the pyroSAR Developers.
+# Copyright (c) 2014-2023, the pyroSAR Developers.
 
 # This file is part of the pyroSAR Project. It is subject to the
 # license terms in the LICENSE.txt file found in the top-level
@@ -19,7 +19,7 @@ import re
 from math import sin, radians
 import inspect
 from datetime import datetime
-from ._dev_config import product_pattern
+from . import patterns
 
 from spatialist.ancillary import finder
 
@@ -41,7 +41,7 @@ def groupby(images, attribute):
     list[list[str]]
         a list of sub-lists containing the grouped images
     """
-    images_sort = sorted(images, key=lambda x: re.search(product_pattern, x).group(attribute))
+    images_sort = sorted(images, key=lambda x: re.search(patterns.pyrosar, x).group(attribute))
     out_meta = [[parse_datasetname(images_sort.pop(0))]]
     while len(images_sort) > 0:
         filename = images_sort.pop(0)
@@ -180,7 +180,7 @@ def parse_datasetname(name, parse_date=False):
     
     filename = os.path.abspath(name) if os.path.isfile(name) else name
     
-    match = re.match(re.compile(product_pattern), filename)
+    match = re.match(re.compile(patterns.pyrosar), filename)
     if not match:
         return
     out = match.groupdict()
@@ -222,7 +222,7 @@ def find_datasets(directory, recursive=False, **kwargs):
     --------
     >>> selection = find_datasets('path/to/files', sensor=('S1A', 'S1B'), polarization='VV')
     """
-    files = finder(directory, [product_pattern], regex=True, recursive=recursive)
+    files = finder(directory, [patterns.pyrosar], regex=True, recursive=recursive)
     selection = []
     for file in files:
         meta = parse_datasetname(file)

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -48,7 +48,7 @@ import progressbar as pb
 from osgeo import gdal, osr, ogr
 from osgeo.gdalconst import GA_ReadOnly
 
-from . import S1
+from . import S1, patterns
 from .ERS import passdb_query, get_angles_resolution
 from .xml_util import getNamespaces
 
@@ -863,19 +863,7 @@ class CEOS_ERS(ID):
     """
     
     def __init__(self, scene):
-        self.pattern = r'(?P<product_id>(?:SAR|ASA)_(?:IM(?:S|P|G|M|_)|AP(?:S|P|G|M|_)|WV(?:I|S|W|_)|WS(?:M|S|_))_[012B][CP])' \
-                       r'(?P<processing_stage_flag>[A-Z])' \
-                       r'(?P<originator_ID>[A-Z\-]{3})' \
-                       r'(?P<start_day>[0-9]{8})_' \
-                       r'(?P<start_time>[0-9]{6})_' \
-                       r'(?P<duration>[0-9]{8})' \
-                       r'(?P<phase>[0-9A-Z]{1})' \
-                       r'(?P<cycle>[0-9]{3})_' \
-                       r'(?P<relative_orbit>[0-9]{5})_' \
-                       r'(?P<absolute_orbit>[0-9]{5})_' \
-                       r'(?P<counter>[0-9]{4,})\.' \
-                       r'(?P<satellite_ID>[EN][12])' \
-                       r'(?P<extension>(?:\.zip|\.tar\.gz|\.PS|))$'
+        self.pattern = patterns.ceos_ers
         
         self.pattern_pid = r'(?P<sat_id>(?:SAR|ASA))_' \
                            r'(?P<image_mode>(?:IM(?:S|P|G|M|_)|AP(?:S|P|G|M|_)|WV(?:I|S|W|_)|WS(?:M|S|_)))_' \
@@ -1042,33 +1030,15 @@ class CEOS_PSR(ID):
         
         self.scene = os.path.realpath(scene)
         
-        patterns = [r'^LED-ALPSR'
-                    r'(?P<sub>P|S)'
-                    r'(?P<orbit>[0-9]{5})'
-                    r'(?P<frame>[0-9]{4})-'
-                    r'(?P<mode>[HWDPC])'
-                    r'(?P<level>1\.[015])'
-                    r'(?P<proc>G|_)'
-                    r'(?P<proj>[UPML_])'
-                    r'(?P<orbit_dir>A|D)$',
-                    r'^LED-ALOS2'
-                    r'(?P<orbit>[0-9]{5})'
-                    r'(?P<frame>[0-9]{4})-'
-                    r'(?P<date>[0-9]{6})-'
-                    r'(?P<mode>SBS|UBS|UBD|HBS|HBD|HBQ|FBS|FBD|FBQ|WBS|WBD|WWS|WWD|VBS|VBD)'
-                    r'(?P<look_dir>L|R)'
-                    r'(?P<level>1\.0|1\.1|1\.5|2\.1|3\.1)'
-                    r'(?P<proc>[GR_])'
-                    r'(?P<proj>[UPML_])'
-                    r'(?P<orbit_dir>A|D)$']
+        candidates = [patterns.ceos_psr1, patterns.ceos_psr2]
         
-        for i, pattern in enumerate(patterns):
+        for i, pattern in enumerate(candidates):
             self.pattern = pattern
             try:
                 self.examine()
                 break
             except RuntimeError as e:
-                if i + 1 == len(patterns):
+                if i + 1 == len(candidates):
                     raise e
         
         self.meta = self.scanMetadata()
@@ -1379,18 +1349,7 @@ class EORC_PSR(ID):
         
         self.scene = os.path.realpath(scene)
         
-        self.pattern = r'^PSR2-' \
-                       r'(?P<prodlevel>SLTR)_' \
-                       r'(?P<pathnr>RSP[0-9]{3})_' \
-                       r'(?P<date>[0-9]{8})' \
-                       r'(?P<mode>FBD|WBD)' \
-                       r'(?P<beam>[0-9]{2})' \
-                       r'(?P<orbit_dir>A|D)' \
-                       r'(?P<look_dir>L|R)_' \
-                       r'(?P<replay_id1>[0-9A-Z]{16})-' \
-                       r'(?P<replay_id2>[0-9A-Z]{5})_' \
-                       r'(?P<internal>[0-9]{3})_' \
-                       r'HDR$'
+        self.pattern = patterns.eorc_psr
         
         self.examine()
         
@@ -1535,18 +1494,7 @@ class ESA(ID):
     
     def __init__(self, scene):
         
-        self.pattern = r'(?P<product_id>(?:SAR|ASA)_(?:IM(?:S|P|G|M|_)|AP(?:S|P|G|M|_)|WV(?:I|S|W|_)|WS(?:M|S|_))_[012B][CP])' \
-                       r'(?P<processing_stage_flag>[A-Z])' \
-                       r'(?P<originator_ID>[A-Z\-]{3})' \
-                       r'(?P<start_day>[0-9]{8})_' \
-                       r'(?P<start_time>[0-9]{6})_' \
-                       r'(?P<duration>[0-9]{8})' \
-                       r'(?P<phase>[0-9A-Z]{1})' \
-                       r'(?P<cycle>[0-9]{3})_' \
-                       r'(?P<relative_orbit>[0-9]{5})_' \
-                       r'(?P<absolute_orbit>[0-9]{5})_' \
-                       r'(?P<counter>[0-9]{4,})\.' \
-                       r'(?P<satellite_ID>[EN][12])'
+        self.pattern = patterns.esa
         self.pattern_pid = r'(?P<sat_id>(?:SAR|ASA))_' \
                            r'(?P<image_mode>(?:IM(?:S|P|G|M|_)|AP(?:S|P|G|M|_)|WV(?:I|S|W|_)|WS(?:M|S|_)))_' \
                            r'(?P<processing_level>[012B][CP])'
@@ -1644,19 +1592,7 @@ class SAFE(ID):
         
         self.scene = os.path.realpath(scene)
         
-        self.pattern = r'^(?P<sensor>S1[AB])_' \
-                       r'(?P<beam>S1|S2|S3|S4|S5|S6|IW|EW|WV|EN|N1|N2|N3|N4|N5|N6|IM)_' \
-                       r'(?P<product>SLC|GRD|OCN)' \
-                       r'(?P<resolution>F|H|M|_)_' \
-                       r'(?P<processingLevel>1|2)' \
-                       r'(?P<category>S|A)' \
-                       r'(?P<pols>SH|SV|DH|DV|VV|HH|HV|VH)_' \
-                       r'(?P<start>[0-9]{8}T[0-9]{6})_' \
-                       r'(?P<stop>[0-9]{8}T[0-9]{6})_' \
-                       r'(?P<orbitNumber>[0-9]{6})_' \
-                       r'(?P<dataTakeID>[0-9A-F]{6})_' \
-                       r'(?P<productIdentifier>[0-9A-F]{4})' \
-                       r'\.SAFE$'
+        self.pattern = patterns.safe
         
         self.pattern_ds = r'^s1[ab]-' \
                           r'(?P<swath>s[1-6]|iw[1-3]?|ew[1-5]?|wv[1-2]|n[1-6])-' \
@@ -2018,14 +1954,7 @@ class TSX(ID):
         if isinstance(scene, str):
             self.scene = os.path.realpath(scene)
             
-            self.pattern = r'^(?P<sat>T[DS]X1)_SAR__' \
-                           r'(?P<prod>SSC|MGD|GEC|EEC)_' \
-                           r'(?P<var>____|SE__|RE__|MON1|MON2|BTX1|BRX2)_' \
-                           r'(?P<mode>SM|SL|HS|HS300|ST|SC)_' \
-                           r'(?P<pols>[SDTQ])_' \
-                           r'(?:SRA|DRA)_' \
-                           r'(?P<start>[0-9]{8}T[0-9]{6})_' \
-                           r'(?P<stop>[0-9]{8}T[0-9]{6})(?:\.xml|)$'
+            self.pattern = patterns.tsx
             
             self.pattern_ds = r'^IMAGE_(?P<pol>HH|HV|VH|VV)_(?:SRA|FWD|AFT)_(?P<beam>[^\.]+)\.(cos|tif)$'
             self.examine(include_folders=False)
@@ -2126,14 +2055,7 @@ class TDM(TSX):
     def __init__(self, scene):
         self.scene = os.path.realpath(scene)
         
-        self.pattern = r'^(?P<sat>T[D]M1)_SAR__' \
-                       r'(?P<prod>COS)_' \
-                       r'(?P<var>____|MONO|BIST|ALT1|ALT2)_' \
-                       r'(?P<mode>SM|SL|HS)_' \
-                       r'(?P<pols>[SDQ])_' \
-                       r'(?:SRA|DRA)_' \
-                       r'(?P<start>[0-9]{8}T[0-9]{6})_' \
-                       r'(?P<stop>[0-9]{8}T[0-9]{6})(?:\.xml|)$'
+        self.pattern = patterns.tdm
         
         self.pattern_ds = r'^IMAGE_(?P<pol>HH|HV|VH|VV)_(?:SRA|FWD|AFT)_(?P<beam>[^\.]+)\.(cos|tif)$'
         self.examine(include_folders=False)

--- a/pyroSAR/patterns.py
+++ b/pyroSAR/patterns.py
@@ -1,0 +1,121 @@
+###############################################################################
+# Reading and Organizing system for SAR images
+# Copyright (c) 2016-2023, the pyroSAR Developers.
+
+# This file is part of the pyroSAR Project. It is subject to the
+# license terms in the LICENSE.txt file found in the top-level
+# directory of this distribution and at
+# https://github.com/johntruckenbrodt/pyroSAR/blob/master/LICENSE.txt.
+# No part of the pyroSAR project, including this file, may be
+# copied, modified, propagated, or distributed except according
+# to the terms contained in the LICENSE.txt file.
+###############################################################################
+"""
+This file contains regular expressions to identify SAR products.
+The pattern 'pyrosar' identifies products in pyroSAR's unified naming scheme.
+The names of all other expressions correspond to the classes found in pyroSAR.drivers.
+"""
+pyrosar = r'(?:.*[/\\]|)' \
+          r'(?P<outname_base>' \
+          r'(?P<sensor>[A-Z0-9]{1,4})_+' \
+          r'(?P<acquisition_mode>[A-Z0-9]{1,4})_+' \
+          r'(?P<orbit>[AD])_' \
+          r'(?P<start>[0-9T]{15})' \
+          r'(?:_(?P<extensions>\w*?)|)' \
+          r')_*' \
+          r'(?:(?P<polarization>[HV]{2})_' \
+          r'(?P<proc_steps>[\w-]*)|)' \
+          r'(?P<filetype>(?:.tif|.nc|))$'
+
+ceos_ers = r'(?P<product_id>(?:SAR|ASA)_(?:IM(?:S|P|G|M|_)|AP(?:S|P|G|M|_)|WV(?:I|S|W|_)|WS(?:M|S|_))_[012B][CP])' \
+           r'(?P<processing_stage_flag>[A-Z])' \
+           r'(?P<originator_ID>[A-Z\-]{3})' \
+           r'(?P<start_day>[0-9]{8})_' \
+           r'(?P<start_time>[0-9]{6})_' \
+           r'(?P<duration>[0-9]{8})' \
+           r'(?P<phase>[0-9A-Z]{1})' \
+           r'(?P<cycle>[0-9]{3})_' \
+           r'(?P<relative_orbit>[0-9]{5})_' \
+           r'(?P<absolute_orbit>[0-9]{5})_' \
+           r'(?P<counter>[0-9]{4,})\.' \
+           r'(?P<satellite_ID>[EN][12])' \
+           r'(?P<extension>(?:\.zip|\.tar\.gz|\.PS|))$'
+
+ceos_psr1 = r'^LED-ALPSR' \
+            r'(?P<sub>P|S)' \
+            r'(?P<orbit>[0-9]{5})' \
+            r'(?P<frame>[0-9]{4})-' \
+            r'(?P<mode>[HWDPC])' \
+            r'(?P<level>1\.[015])' \
+            r'(?P<proc>G|_)' \
+            r'(?P<proj>[UPML_])' \
+            r'(?P<orbit_dir>A|D)$'
+
+ceos_psr2 = r'^LED-ALOS2' \
+            r'(?P<orbit>[0-9]{5})' \
+            r'(?P<frame>[0-9]{4})-' \
+            r'(?P<date>[0-9]{6})-' \
+            r'(?P<mode>SBS|UBS|UBD|HBS|HBD|HBQ|FBS|FBD|FBQ|WBS|WBD|WWS|WWD|VBS|VBD)' \
+            r'(?P<look_dir>L|R)' \
+            r'(?P<level>1\.0|1\.1|1\.5|2\.1|3\.1)' \
+            r'(?P<proc>[GR_])' \
+            r'(?P<proj>[UPML_])' \
+            r'(?P<orbit_dir>A|D)$'
+
+eorc_psr = r'^PSR2-' \
+           r'(?P<prodlevel>SLTR)_' \
+           r'(?P<pathnr>RSP[0-9]{3})_' \
+           r'(?P<date>[0-9]{8})' \
+           r'(?P<mode>FBD|WBD)' \
+           r'(?P<beam>[0-9]{2})' \
+           r'(?P<orbit_dir>A|D)' \
+           r'(?P<look_dir>L|R)_' \
+           r'(?P<replay_id1>[0-9A-Z]{16})-' \
+           r'(?P<replay_id2>[0-9A-Z]{5})_' \
+           r'(?P<internal>[0-9]{3})_' \
+           r'HDR$'
+
+esa = r'(?P<product_id>(?:SAR|ASA)_(?:IM(?:S|P|G|M|_)|AP(?:S|P|G|M|_)|WV(?:I|S|W|_)|WS(?:M|S|_))_[012B][CP])' \
+      r'(?P<processing_stage_flag>[A-Z])' \
+      r'(?P<originator_ID>[A-Z\-]{3})' \
+      r'(?P<start_day>[0-9]{8})_' \
+      r'(?P<start_time>[0-9]{6})_' \
+      r'(?P<duration>[0-9]{8})' \
+      r'(?P<phase>[0-9A-Z]{1})' \
+      r'(?P<cycle>[0-9]{3})_' \
+      r'(?P<relative_orbit>[0-9]{5})_' \
+      r'(?P<absolute_orbit>[0-9]{5})_' \
+      r'(?P<counter>[0-9]{4,})\.' \
+      r'(?P<satellite_ID>[EN][12])'
+
+safe = r'^(?P<sensor>S1[AB])_' \
+       r'(?P<beam>S1|S2|S3|S4|S5|S6|IW|EW|WV|EN|N1|N2|N3|N4|N5|N6|IM)_' \
+       r'(?P<product>SLC|GRD|OCN)' \
+       r'(?P<resolution>F|H|M|_)_' \
+       r'(?P<processingLevel>1|2)' \
+       r'(?P<category>S|A)' \
+       r'(?P<pols>SH|SV|DH|DV|VV|HH|HV|VH)_' \
+       r'(?P<start>[0-9]{8}T[0-9]{6})_' \
+       r'(?P<stop>[0-9]{8}T[0-9]{6})_' \
+       r'(?P<orbitNumber>[0-9]{6})_' \
+       r'(?P<dataTakeID>[0-9A-F]{6})_' \
+       r'(?P<productIdentifier>[0-9A-F]{4})' \
+       r'\.SAFE$'
+
+tsx = r'^(?P<sat>T[DS]X1)_SAR__' \
+      r'(?P<prod>SSC|MGD|GEC|EEC)_' \
+      r'(?P<var>____|SE__|RE__|MON1|MON2|BTX1|BRX2)_' \
+      r'(?P<mode>SM|SL|HS|HS300|ST|SC)_' \
+      r'(?P<pols>[SDTQ])_' \
+      r'(?:SRA|DRA)_' \
+      r'(?P<start>[0-9]{8}T[0-9]{6})_' \
+      r'(?P<stop>[0-9]{8}T[0-9]{6})(?:\.xml|)$'
+
+tdm = r'^(?P<sat>T[D]M1)_SAR__' \
+      r'(?P<prod>COS)_' \
+      r'(?P<var>____|MONO|BIST|ALT1|ALT2)_' \
+      r'(?P<mode>SM|SL|HS)_' \
+      r'(?P<pols>[SDQ])_' \
+      r'(?:SRA|DRA)_' \
+      r'(?P<start>[0-9]{8}T[0-9]{6})_' \
+      r'(?P<stop>[0-9]{8}T[0-9]{6})(?:\.xml|)$'


### PR DESCRIPTION
The classes for reading SAR data in `pyroSAR.drivers` contain regular expressions for identifying product file/folder names. Furthermore, the file `_dev_config.py` contained a pattern for identifying files with pyroSAR's unified naming scheme.  
These patterns have now been outsourced into a new module `pyroSAR.patterns` for convenient reuse in other tools.