### PR TITLE
Adding refined selection via geometry as opt-in select argument

### DIFF
--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -3441,13 +3441,13 @@ def compare_vector_to_many_geometries_by_name(vector, filepaths):
         list containing the overlapping files' names
     """
     refined = []
-    results = identify_many(filepaths)
     with vector.clone() as vec:
         vec.reproject(4326)
         site_geom = vec.convert2wkt(set3D=False)[0]
         site_geom = ogr.CreateGeometryFromWkt(site_geom)
         
-        for s in results:
+        for s in filepaths:
+            s = identify(s)
             geometry = s.geometry()
             geometry.reproject(4326)
             geometry = geometry.convert2wkt(set3D=False)[0]


### PR DESCRIPTION
added argument by_geometry to Archive.select, this will iterate over the found scenes and only returns overlapping ones with the geometry instead of the footprint.

Most time is spent in the identify, maybe there is a slimmed down approach to get the geometry faster?
Directly intersect spatialist.Vector takes longer than the ogr conversion (230s vs 130s on ~1300 scenes)

hope this helps :)