### PR TITLE
[S1.OSV.catch] fixed bug in finding files starting in previous month

### DIFF
--- a/pyroSAR/S1/auxil.py
+++ b/pyroSAR/S1/auxil.py
@@ -1,7 +1,7 @@
 ###############################################################################
 # general utilities for Sentinel-1
 
-# Copyright (c) 2016-2021, the pyroSAR Developers.
+# Copyright (c) 2016-2023, the pyroSAR Developers.
 
 # This file is part of the pyroSAR Project. It is subject to the
 # license terms in the LICENSE.txt file found in the top-level
@@ -21,6 +21,7 @@ import zipfile as zf
 from io import BytesIO
 from datetime import datetime, timedelta
 from dateutil import parser as dateutil_parser
+from dateutil.relativedelta import relativedelta
 import xml.etree.ElementTree as ET
 import numpy as np
 from osgeo import gdal
@@ -234,6 +235,7 @@ class OSV(object):
             date_search = datetime(year=start.year,
                                    month=start.month,
                                    day=1)
+            date_search -= relativedelta(months=1)
             busy = True
             while busy:
                 url_sub = skeleton.format(url=url,
@@ -258,11 +260,9 @@ class OSV(object):
                                       'auth': None})
                     if start2 >= stop:
                         busy = False
-                if date_search.month < 12:
-                    date_search = date_search.replace(month=date_search.month + 1)
-                else:
-                    date_search = date_search.replace(year=date_search.year + 1, month=1)
-        
+                date_search += relativedelta(months=1)
+                if date_search > datetime.now():
+                    busy = False
         return files
     
     def __catch_gnss(self, sensor, start, stop, osvtype='POE'):

--- a/tests/test_osv.py
+++ b/tests/test_osv.py
@@ -37,7 +37,12 @@ def test_scene_osv(tmpdir, testdata):
             os.remove(item)
         assert len(osv.getLocals('POE')) == 1
         res = osv.catch(sensor='S1A', osvtype='RES', start='20210201T00000', stop='20210201T150000', url_option=1)
-        assert len(res) == 9
+        assert len(res) == 11
         osv.retrieve(res[0:3])
         assert len(osv.getLocals('RES')) == 3
-        res = osv.catch(sensor='S1A', osvtype='POE', start=time.strftime('%Y%m%dT%H%M%S'))
+        # check retrieving files for the current day (e.g. to ensure that search is not extended to the future)
+        poe = osv.catch(sensor='S1A', osvtype='POE', start=time.strftime('%Y%m%dT%H%M%S'))
+        assert len(poe) == 0
+        # check retrieving files whose start is in the previous month of the search start
+        poe = osv.catch(sensor='S1A', osvtype='POE', start='20220201T163644', stop='20220201T163709')
+        assert len(poe) == 1


### PR DESCRIPTION
The OSV files comprise info for a certain time range of acquisition. Previously, files whose time range started in the previous month of the defined acquisition start were not found.  
Example:
- scene: `S1A_IW_GRDH_1SDV_20220201T163644_20220201T163709_041722_04F6E6_61EB` (start in Feb. '22)
- OSV: `S1A_OPER_AUX_POEORB_OPOD_20220221T081611_V20220131T225942_20220202T005942` (start in Jan. '22)

closes #285