### PR TITLE
fix name laundering in export2shp

### DIFF
--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -2740,12 +2740,12 @@ class Archive(object):
                          'cycleNumber': 'cycleNr',
                          'frameNumber': 'frameNr',
                          'outname_base': 'outname'}
-        
-        sel_tables = ', '.join([f'{s} as {launder_names[s]}' if s in launder_names else s
-                                for s in self.get_colnames(table)])
 
         if self.driver == 'sqlite':
-            gdal.VectorTranslate(destNameOrDestDS=path, srcDS=self.dbfile, 
+            sel_tables = ', '.join([f'{s} as {launder_names[s]}' if s in launder_names else s
+                                    for s in self.get_colnames(table)])
+            
+            gdal.VectorTranslate(destNameOrDestDS=path, srcDS=self.dbfile,
                                  options=f'-f "ESRI Shapefile" -sql "SELECT {sel_tables} FROM {table}"')
         
         if self.driver == 'postgresql':
@@ -2757,7 +2757,9 @@ class Archive(object):
                                                                        self.url_dict['password'])
             # subprocess.call(['ogr2ogr', '-f', 'ESRI Shapefile', path,
             #                  db_connection, table])
-            gdal.VectorTranslate(destNameOrDestDS=path, srcDS=db_connection, 
+            sel_tables = ', '.join([f'data.{s} as {launder_names[s]}' if s in launder_names else s
+                                    for s in self.get_colnames(table)])
+            gdal.VectorTranslate(destNameOrDestDS=path, srcDS=db_connection,
                                  options=f'-f "ESRI Shapefile" -sql "SELECT {sel_tables} FROM {table}"')
     
     def filter_scenelist(self, scenelist):

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -1,6 +1,6 @@
 ###############################################################################
 # Reading and Organizing system for SAR images
-# Copyright (c) 2016-2023, the pyroSAR Developers.
+# Copyright (c) 2016-2024, the pyroSAR Developers.
 
 # This file is part of the pyroSAR Project. It is subject to the
 # license terms in the LICENSE.txt file found in the top-level
@@ -2747,12 +2747,8 @@ class Archive(object):
         if self.driver == 'sqlite':
             srcDS = self.dbfile
         elif self.driver == 'postgresql':
-            srcDS = """PG:host={0} port={1} user={2}
-                dbname={3} password={4} active_schema=public""".format(self.url_dict['host'],
-                                                                       self.url_dict['port'],
-                                                                       self.url_dict['username'],
-                                                                       self.url_dict['database'],
-                                                                       self.url_dict['password'])
+            srcDS = """PG:host={host} port={port} user={username}
+            dbname={database} password={password} active_schema=public""".format(**self.url_dict)
         else:
             raise RuntimeError('unknown archive driver')
         

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -2722,7 +2722,7 @@ class Archive(object):
         Returns
         -------
         """
-        if table not in ['data', 'duplicates']:
+        if table not in self.get_tablenames():
             log.warning('Only data and duplicates can be exported!')
             return
         
@@ -2734,11 +2734,19 @@ class Archive(object):
         dirname = os.path.dirname(path)
         os.makedirs(dirname, exist_ok=True)
         
-        # uses spatialist.ogr2ogr to write shps with given path (or db connection)
+        launder_names = {'acquisition_mode': 'acq_mode',
+                         'orbitNumber_abs': 'orbit_abs',
+                         'orbitNumber_rel': 'orbit_rel',
+                         'cycleNumber': 'cycleNr',
+                         'frameNumber': 'frameNr',
+                         'outname_base': 'outname'}
+        
+        sel_tables = ', '.join([f'{s} as {launder_names[s]}' if s in launder_names else s
+                                for s in self.get_colnames(table)])
+
         if self.driver == 'sqlite':
-            # ogr2ogr(self.dbfile, path, options={'format': 'ESRI Shapefile'})
-            subprocess.call(['ogr2ogr', '-f', 'ESRI Shapefile', path,
-                             self.dbfile, table])
+            gdal.VectorTranslate(destNameOrDestDS=path, srcDS=self.dbfile, 
+                                 options=f'-f "ESRI Shapefile" -sql "SELECT {sel_tables} FROM {table}"')
         
         if self.driver == 'postgresql':
             db_connection = """PG:host={0} port={1} user={2}
@@ -2747,9 +2755,10 @@ class Archive(object):
                                                                        self.url_dict['username'],
                                                                        self.url_dict['database'],
                                                                        self.url_dict['password'])
-            # ogr2ogr(db_connection, path, options={'format': 'ESRI Shapefile'})
-            subprocess.call(['ogr2ogr', '-f', 'ESRI Shapefile', path,
-                             db_connection, table])
+            # subprocess.call(['ogr2ogr', '-f', 'ESRI Shapefile', path,
+            #                  db_connection, table])
+            gdal.VectorTranslate(destNameOrDestDS=path, srcDS=db_connection, 
+                                 options=f'-f "ESRI Shapefile" -sql "SELECT {sel_tables} FROM {table}"')
     
     def filter_scenelist(self, scenelist):
         """


### PR DESCRIPTION
Added a dict with shorter names in export2shp, using SQL to rename columns and switched to gdal.VectorTranslate for export. Postgres did not work locally, needs testing