### PR TITLE
[Archive] replace column 'bbox' with 'geometry'

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -17,6 +17,7 @@ dependencies:
   - pillow
   - lxml
   - packaging
+  - libspatialite>=5.1.0
   - coveralls
   - coverage
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - pillow
   - lxml
   - packaging
+  - libspatialite>=5.1.0

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -2292,7 +2292,7 @@ class Archive(object):
         # check for driver, if postgres then check if server is reachable
         if not postgres:
             self.driver = 'sqlite'
-            dirname = os.path.dirname(dbfile)
+            dirname = os.path.dirname(os.path.abspath(dbfile))
             w_ok = os.access(dirname, os.W_OK)
             if not w_ok:
                 raise RuntimeError('cannot write to directory {}'.format(dirname))

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -2288,7 +2288,7 @@ class Archive(object):
         
         if dbfile.endswith('.csv'):
             raise RuntimeError("Please create a new Archive database and import the"
-                               "csv-file using db.import_outdated('<file>.csv').")
+                               "CSV file using db.import_outdated('<file>.csv').")
         # check for driver, if postgres then check if server is reachable
         if not postgres:
             self.driver = 'sqlite'
@@ -2332,7 +2332,7 @@ class Archive(object):
         self.engine = create_engine(url=self.url, echo=False,
                                     connect_args=connect_args)
         
-        # call to ____load_spatialite() for sqlite, to load mod_spatialite via event handler listen()
+        # call to __load_spatialite() for sqlite, to load mod_spatialite via event handler listen()
         if self.driver == 'sqlite':
             log.debug('loading spatialite extension')
             listen(target=self.engine, identifier='connect', fn=self.__load_spatialite)
@@ -2366,16 +2366,15 @@ class Archive(object):
         self.__init_data_table()
         self.__init_duplicates_table()
         
+        msg = ("the 'data' table is missing {}. Please create a new database "
+               "and import the old one opened in legacy mode using "
+               "Archive.import_outdated.")
         pk = sql_inspect(self.data_schema).primary_key
         if 'product' not in pk.columns.keys() and not legacy:
-            raise RuntimeError("the 'data' table is missing a primary key 'product'. "
-                               "Please create a new database and import the old one "
-                               "opened in legacy mode using Archive.import_outdated.")
+            raise RuntimeError(msg.format("a primary key 'product'"))
         
         if 'geometry' not in self.get_colnames() and not legacy:
-            raise RuntimeError("the 'data' table is missing the 'geometry' column. "
-                               "Please create a new database and import the old one "
-                               "opened in legacy mode using Archive.import_outdated.")
+            raise RuntimeError(msg.format("the 'geometry' column"))
         
         self.Base = automap_base(metadata=self.meta)
         self.Base.prepare(self.engine, reflect=True)
@@ -2447,7 +2446,7 @@ class Archive(object):
                                  Column('hv', Integer),
                                  Column('vh', Integer),
                                  Column('geometry', Geometry(geometry_type='POLYGON',
-                                                         management=True, srid=4326)))
+                                                             management=True, srid=4326)))
         # add custom fields
         if self.custom_fields is not None:
             for key, val in self.custom_fields.items():

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -2865,9 +2865,7 @@ class Archive(object):
         -------
 
         """
-        print('importing outdated database')
         if isinstance(dbfile, str) and dbfile.endswith('csv'):
-            print('importing CSV file')
             with open(dbfile) as csvfile:
                 text = csvfile.read()
                 csvfile.seek(0)
@@ -2878,15 +2876,13 @@ class Archive(object):
                     scenes.append(row['scene'])
                 self.insert(scenes)
         elif isinstance(dbfile, Archive):
-            print('importing Archive object')
-            if not 'geometry' in dbfile.get_colnames():
-                scenes = dbfile.conn.execute('SELECT scene from data')
-                scenes = [s.scene for s in scenes]
-                self.insert(scenes)
-            else:
-                select = dbfile.conn.execute('SELECT * from data')
-                #print(select.first())
-                self.conn.execute(insert(self.Data).values(*select))
+            #if not 'geometry' in dbfile.get_colnames():
+            scenes = dbfile.conn.execute('SELECT scene from data')
+            scenes = [s.scene for s in scenes]
+            self.insert(scenes)
+            #else:  # todo: see error in tests
+            #    select = dbfile.conn.execute('SELECT * from data')
+            #    self.conn.execute(insert(self.Data).values(*select))
             # duplicates in older databases may fit into the new data table
             reinsert = dbfile.select_duplicates(value='scene')
             if reinsert is not None:

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -2876,14 +2876,9 @@ class Archive(object):
                     scenes.append(row['scene'])
                 self.insert(scenes)
         elif isinstance(dbfile, Archive):
-            #if not 'geometry' in dbfile.get_colnames():
             scenes = dbfile.conn.execute('SELECT scene from data')
             scenes = [s.scene for s in scenes]
             self.insert(scenes)
-            #else:  # todo: see error in tests
-            #    select = dbfile.conn.execute('SELECT * from data')
-            #    self.conn.execute(insert(self.Data).values(*select))
-            # duplicates in older databases may fit into the new data table
             reinsert = dbfile.select_duplicates(value='scene')
             if reinsert is not None:
                 self.insert(reinsert)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ GeoAlchemy2<0.14.0
 Pillow
 lxml
 packaging
-libspatialite>=5.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ GeoAlchemy2<0.14.0
 Pillow
 lxml
 packaging
+libspatialite>=5.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,9 +39,9 @@ def testdata(testdir):
         # used in test_osv
         's1_orbit': os.path.join(testdir, 'S1A_IW_GRDH_1SDV_20210119T031653_20210119T031718_036201_043ED0_8255.zip'),
         'tif': os.path.join(testdir, 'S1A__IW___A_20150309T173017_VV_grd_mli_geo_norm_db.tif'),
-        'archive_old': os.path.join(testdir, 'archive_outdated.csv'),
-        'archive_old_db': os.path.join(testdir, 'archive_outdated.db'),
-        'archive_new_db': os.path.join(testdir, 'archive_with_geometry.db'),
+        'archive_old_csv': os.path.join(testdir, 'archive_outdated.csv'),
+        'archive_old_bbox': os.path.join(testdir, 'archive_outdated_bbox.db'),
+        'archive': os.path.join(testdir, 'archive.db'),
         'dempar': os.path.join(testdir, 'dem.par'),
         'mlipar': os.path.join(testdir, 'mli.par')
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,6 @@ def testdata(testdir):
         'tif': os.path.join(testdir, 'S1A__IW___A_20150309T173017_VV_grd_mli_geo_norm_db.tif'),
         'archive_old_csv': os.path.join(testdir, 'archive_outdated.csv'),
         'archive_old_bbox': os.path.join(testdir, 'archive_outdated_bbox.db'),
-        'archive': os.path.join(testdir, 'archive.db'),
         'dempar': os.path.join(testdir, 'dem.par'),
         'mlipar': os.path.join(testdir, 'mli.par')
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,8 @@ def testdata(testdir):
         's1_orbit': os.path.join(testdir, 'S1A_IW_GRDH_1SDV_20210119T031653_20210119T031718_036201_043ED0_8255.zip'),
         'tif': os.path.join(testdir, 'S1A__IW___A_20150309T173017_VV_grd_mli_geo_norm_db.tif'),
         'archive_old': os.path.join(testdir, 'archive_outdated.csv'),
+        'archive_old_db': os.path.join(testdir, 'archive_outdated.db'),
+        'archive_new_db': os.path.join(testdir, 'archive_with_geometry.db'),
         'dempar': os.path.join(testdir, 'dem.par'),
         'mlipar': os.path.join(testdir, 'mli.par')
     }

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -205,9 +205,16 @@ def test_archive2(tmpdir, testdata):
     with pytest.raises(OSError):
         with pyroSAR.Archive(dbfile) as db:
             db.import_outdated(testdata['archive_old_csv'])
+    
+    # the archive_old_bbox database contains a relative file name for the scene
+    # so that it can be reimported into the new database. The working directory
+    # is changed temporarily so that the scene can be found.
+    cwd = os.getcwd()
+    os.chdir('data')
     with pyroSAR.Archive(dbfile) as db:
         with pyroSAR.Archive(testdata['archive_old_bbox'], legacy=True) as db_old:
             db.import_outdated(db_old)
+    os.chdir(cwd)
     
     with pytest.raises(RuntimeError):
         db = pyroSAR.Archive(testdata['archive_old_csv'])

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -210,7 +210,8 @@ def test_archive2(tmpdir, testdata):
     # so that it can be reimported into the new database. The working directory
     # is changed temporarily so that the scene can be found.
     cwd = os.getcwd()
-    os.chdir('data')
+    folder = os.path.dirname(os.path.realpath(__file__))
+    os.chdir(os.path.join(folder, 'data'))
     with pyroSAR.Archive(dbfile) as db:
         with pyroSAR.Archive(testdata['archive_old_bbox'], legacy=True) as db_old:
             db.import_outdated(db_old)
@@ -253,14 +254,16 @@ def test_archive_postgres(tmpdir, testdata):
     with pytest.raises(TypeError):
         db.filter_scenelist([1])
     db.close()
-    with pyroSAR.Archive('test', postgres=True, port=pgport, user=pguser, password=pgpassword) as db:
+    with pyroSAR.Archive('test', postgres=True, port=pgport,
+                         user=pguser, password=pgpassword) as db:
         assert db.size == (1, 0)
         shp = os.path.join(str(tmpdir), 'db.shp')
         db.export2shp(shp)
         pyroSAR.drop_archive(db)
     assert Vector(shp).nfeatures == 1
     
-    with pyroSAR.Archive('test', postgres=True, port=pgport, user=pguser, password=pgpassword) as db:
+    with pyroSAR.Archive('test', postgres=True, port=pgport,
+                         user=pguser, password=pgpassword) as db:
         with pytest.raises(OSError):
             db.import_outdated(testdata['archive_old_csv'])
         pyroSAR.drop_archive(db)
@@ -269,7 +272,8 @@ def test_archive_postgres(tmpdir, testdata):
     # so that it can be reimported into the new database. The working directory
     # is changed temporarily so that the scene can be found.
     cwd = os.getcwd()
-    os.chdir('data')
+    folder = os.path.dirname(os.path.realpath(__file__))
+    os.chdir(os.path.join(folder, 'data'))
     with pyroSAR.Archive('test', postgres=True, port=pgport,
                          user=pguser, password=pgpassword) as db:
         with pyroSAR.Archive(testdata['archive_old_bbox'], legacy=True) as db_old:

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -204,16 +204,17 @@ def test_archive2(tmpdir, testdata):
     
     with pytest.raises(OSError):
         with pyroSAR.Archive(dbfile) as db:
-            db.import_outdated(testdata['archive_old'])
+            db.import_outdated(testdata['archive_old_csv'])
     with pyroSAR.Archive(dbfile) as db:
-        with pyroSAR.Archive(testdata['archive_old_db'], legacy=True) as db_old:
+        with pyroSAR.Archive(testdata['archive_old_bbox'], legacy=True) as db_old:
             db.import_outdated(db_old)
-            
+    
     with pytest.raises(RuntimeError):
-        db = pyroSAR.Archive(testdata['archive_old'])
+        db = pyroSAR.Archive(testdata['archive_old_csv'])
     with pytest.raises(RuntimeError):
-        db = pyroSAR.Archive(testdata['archive_old_db'])
-    db = pyroSAR.Archive(testdata['archive_new_db'])
+        db = pyroSAR.Archive(testdata['archive_old_bbox'])
+    db = pyroSAR.Archive(testdata['archive'])
+
 
 def test_archive_postgres(tmpdir, testdata):
     pguser = os.environ.get('PGUSER')
@@ -255,16 +256,16 @@ def test_archive_postgres(tmpdir, testdata):
     
     with pyroSAR.Archive('test', postgres=True, port=pgport, user=pguser, password=pgpassword) as db:
         with pytest.raises(OSError):
-            db.import_outdated(testdata['archive_old'])
+            db.import_outdated(testdata['archive_old_csv'])
         pyroSAR.drop_archive(db)
     
     with pyroSAR.Archive('test', postgres=True, port=pgport, user=pguser, password=pgpassword) as db:
-        with pyroSAR.Archive(testdata['archive_old_db'], legacy=True) as db_old:
+        with pyroSAR.Archive(testdata['archive_old_bbox'], legacy=True) as db_old:
             db.import_outdated(db_old)
         pyroSAR.drop_archive(db)
-        
+    
     with pyroSAR.Archive('test', postgres=True, port=pgport, user=pguser, password=pgpassword) as db:
-        with pyroSAR.Archive(testdata['archive_new_db'], legacy=True) as db_new:
+        with pyroSAR.Archive(testdata['archive'], legacy=True) as db_new:
             db.import_outdated(db_new)
         pyroSAR.drop_archive(db)
     

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -204,7 +204,24 @@ def test_archive2(tmpdir, testdata):
     with pytest.raises(OSError):
         with pyroSAR.Archive(dbfile) as db:
             db.import_outdated(testdata['archive_old'])
-
+            
+    with pyroSAR.Archive(dbfile) as db:
+        with pyroSAR.Archive(testdata['archive_old_db'], legacy=True) as db_old:
+            db.import_outdated(db_old)
+    
+    # currently not working,
+    # sqlalchemy.exc.ArgumentError:
+    # Only a single dictionary/tuple or list of dictionaries/tuples is accepted positionally.
+    # fix could be to re-insert all scenes as in the test above
+    # with pyroSAR.Archive(dbfile) as db:
+    #     with pyroSAR.Archive(testdata['archive_new_db'], legacy=True) as db_new:
+    #         db.import_outdated(db_new)
+    
+    with pytest.raises(RuntimeError):
+        db = pyroSAR.Archive(testdata['archive_old'])
+    with pytest.raises(RuntimeError):
+        db = pyroSAR.Archive(testdata['archive_old_db'])
+    db = pyroSAR.Archive(testdata['archive_new_db'])
 
 def test_archive_postgres(tmpdir, testdata):
     pguser = os.environ.get('PGUSER')
@@ -247,6 +264,16 @@ def test_archive_postgres(tmpdir, testdata):
     with pyroSAR.Archive('test', postgres=True, port=pgport, user=pguser, password=pgpassword) as db:
         with pytest.raises(OSError):
             db.import_outdated(testdata['archive_old'])
+        pyroSAR.drop_archive(db)
+    
+    with pyroSAR.Archive('test', postgres=True, port=pgport, user=pguser, password=pgpassword) as db:
+        with pyroSAR.Archive(testdata['archive_old_db'], legacy=True) as db_old:
+            db.import_outdated(db_old)
+        pyroSAR.drop_archive(db)
+        
+    with pyroSAR.Archive('test', postgres=True, port=pgport, user=pguser, password=pgpassword) as db:
+        with pyroSAR.Archive(testdata['archive_new_db'], legacy=True) as db_new:
+            db.import_outdated(db_new)
         pyroSAR.drop_archive(db)
     
     with pytest.raises(SystemExit) as pytest_wrapped_e:

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -265,10 +265,17 @@ def test_archive_postgres(tmpdir, testdata):
             db.import_outdated(testdata['archive_old_csv'])
         pyroSAR.drop_archive(db)
     
-    with pyroSAR.Archive('test', postgres=True, port=pgport, user=pguser, password=pgpassword) as db:
+    # the archive_old_bbox database contains a relative file name for the scene
+    # so that it can be reimported into the new database. The working directory
+    # is changed temporarily so that the scene can be found.
+    cwd = os.getcwd()
+    os.chdir('data')
+    with pyroSAR.Archive('test', postgres=True, port=pgport,
+                         user=pguser, password=pgpassword) as db:
         with pyroSAR.Archive(testdata['archive_old_bbox'], legacy=True) as db_old:
             db.import_outdated(db_old)
         pyroSAR.drop_archive(db)
+    os.chdir(cwd)
     
     dbfile = os.path.join(str(tmpdir), 'scenes.db')
     with pyroSAR.Archive('test', postgres=True, port=pgport,

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -220,7 +220,6 @@ def test_archive2(tmpdir, testdata):
         db = pyroSAR.Archive(testdata['archive_old_csv'])
     with pytest.raises(RuntimeError):
         db = pyroSAR.Archive(testdata['archive_old_bbox'])
-    db = pyroSAR.Archive(testdata['archive'])
 
 
 def test_archive_postgres(tmpdir, testdata):
@@ -271,9 +270,11 @@ def test_archive_postgres(tmpdir, testdata):
             db.import_outdated(db_old)
         pyroSAR.drop_archive(db)
     
-    with pyroSAR.Archive('test', postgres=True, port=pgport, user=pguser, password=pgpassword) as db:
-        with pyroSAR.Archive(testdata['archive'], legacy=True) as db_new:
-            db.import_outdated(db_new)
+    dbfile = os.path.join(str(tmpdir), 'scenes.db')
+    with pyroSAR.Archive('test', postgres=True, port=pgport,
+                         user=pguser, password=pgpassword) as db:
+        with pyroSAR.Archive(dbfile, legacy=True) as db_sqlite:
+            db.import_outdated(db_sqlite)
         pyroSAR.drop_archive(db)
     
     with pytest.raises(SystemExit) as pytest_wrapped_e:

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -201,22 +201,14 @@ def test_archive2(tmpdir, testdata):
     os.remove(dbfile)
     assert not os.path.isfile(dbfile)
     assert Vector(shp).nfeatures == 1
+    
     with pytest.raises(OSError):
         with pyroSAR.Archive(dbfile) as db:
             db.import_outdated(testdata['archive_old'])
-            
     with pyroSAR.Archive(dbfile) as db:
         with pyroSAR.Archive(testdata['archive_old_db'], legacy=True) as db_old:
             db.import_outdated(db_old)
-    
-    # currently not working,
-    # sqlalchemy.exc.ArgumentError:
-    # Only a single dictionary/tuple or list of dictionaries/tuples is accepted positionally.
-    # fix could be to re-insert all scenes as in the test above
-    # with pyroSAR.Archive(dbfile) as db:
-    #     with pyroSAR.Archive(testdata['archive_new_db'], legacy=True) as db_new:
-    #         db.import_outdated(db_new)
-    
+            
     with pytest.raises(RuntimeError):
         db = pyroSAR.Archive(testdata['archive_old'])
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
replaces the column `bbox` with `geometry` containing the footprint geometry instead of the bounding box. Import of old databases can be done with `import_outdated`.