### PR TITLE
[snap.auxil.gpt] fixed bug in removing BNR node

### DIFF
--- a/pyroSAR/snap/auxil.py
+++ b/pyroSAR/snap/auxil.py
@@ -15,6 +15,7 @@ import os
 import re
 import copy
 import shutil
+import traceback
 import subprocess as sp
 from xml.dom import minidom
 import xml.etree.ElementTree as ET
@@ -408,6 +409,8 @@ def gpt(xmlfile, tmpdir, groups=None, cleanup=True,
         else:
             execute(xmlfile, cleanup=cleanup, gpt_exceptions=gpt_exceptions, gpt_args=gpt_args)
     except Exception:
+        tb = traceback.format_exc()
+        log.info(tb)
         log.info('failed: {}'.format(xmlfile))
         raise
     finally:

--- a/pyroSAR/snap/auxil.py
+++ b/pyroSAR/snap/auxil.py
@@ -378,7 +378,7 @@ def gpt(xmlfile, tmpdir, groups=None, cleanup=True,
         del workflow['Remove-GRD-Border-Noise']
         # remove the node name from the groups
         i = 0
-        while i < len(groups) - 1:
+        while i < len(groups):
             if 'Remove-GRD-Border-Noise' in groups[i]:
                 del groups[i][groups[i].index('Remove-GRD-Border-Noise')]
             if len(groups[i]) == 0:

--- a/pyroSAR/snap/util.py
+++ b/pyroSAR/snap/util.py
@@ -14,6 +14,7 @@
 import os
 import re
 import shutil
+import traceback
 from ..drivers import identify, identify_many, ID
 from .auxil import parse_recipe, parse_node, gpt, groupbyWorkers, writer, \
     windows_fileprefix, orb_parametrize, geo_parametrize, sub_parametrize, \
@@ -641,10 +642,10 @@ def geocode(infile, outdir, t_srs=4326, spacing=20, polarizations='all', shapefi
                 removeS1BorderNoiseMethod=removeS1BorderNoiseMethod)
             writer(xmlfile=wf_name, outdir=outdir, basename_extensions=basename_extensions,
                    clean_edges=clean_edges, clean_edges_npixels=clean_edges_npixels)
-        except Exception as e:
-            log.info(str(e))
+        except:
+            tb = traceback.format_exc()
             with open(wf_name.replace('_proc.xml', '_error.log'), 'w') as logfile:
-                logfile.write(str(e))
+                logfile.write(tb)
         finally:
             if cleanup and os.path.isdir(outname):
                 log.info('deleting temporary files')


### PR DESCRIPTION
When custom pyroSAR border noise removal is applied, the `Remove-GRD-Border-Noise` node needs to be removed from the workflow. This was not done in a case where no workflow splitting was applied.  
Furthermore, the error logging was insufficient for identifying the problem. This has been improved.