### PR TITLE
[snap.auxil.parse_node] remove weird placeholder XML node in BandMaths

### DIFF
--- a/pyroSAR/snap/auxil.py
+++ b/pyroSAR/snap/auxil.py
@@ -142,6 +142,10 @@ def parse_node(name, use_existing=True):
                          'validExpression', 'spectralBandIndex']:
                 el = tband.find('.//{}'.format(item))
                 tband.remove(el)
+            for item in ['targetBands', 'variables']:
+                elem = tree.find(f'.//{item}')
+                pl = elem.find('.//_.002e..')
+                elem.remove(pl)
         tree.find('.//parameters').set('class', 'com.bc.ceres.binding.dom.XppDomElement')
         node = Node(node)
         


### PR DESCRIPTION
The parsed `BandMaths` node of SNAP 10 contained some weird placeholder node with name `_.002e..`. This is now removed.