### PR TITLE
fixed bug in reading/writing snap properties

### DIFF
--- a/pyroSAR/examine.py
+++ b/pyroSAR/examine.py
@@ -530,10 +530,7 @@ class SnapProperties(object):
         if value is not None:
             value = str(value).encode('unicode-escape').decode()
             value = value.replace(':', '\\:')
-        if key in ['snap.home', 'snap.userdir']:
-            path = os.path.join(os.path.expanduser('~'),
-                                '.snap', 'etc', 'snap.properties')
-        elif key in self.properties:
+        if key in self.properties:
             path = self.userpath_properties
         elif key in self.auxdata_properties:
             path = self.userpath_auxdata_properties

--- a/pyroSAR/examine.py
+++ b/pyroSAR/examine.py
@@ -529,6 +529,7 @@ class SnapProperties(object):
             self.auxdata_properties[key] = value
         if value is not None:
             value = str(value).encode('unicode-escape').decode()
+            value = value.replace(':', '\\:')
         if key in ['snap.home', 'snap.userdir']:
             path = os.path.join(os.path.expanduser('~'),
                                 '.snap', 'etc', 'snap.properties')
@@ -593,7 +594,7 @@ class SnapProperties(object):
                 try:
                     return float(string)
                 except ValueError:
-                    return string.replace('\\\\', '\\')
+                    return string.replace('\\:', ':').replace('\\\\', '\\')
     
     def keys(self):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import platform
 
 
 @pytest.fixture
@@ -21,7 +22,8 @@ def testdir():
 def testdata(testdir):
     out = {
         # ASAR_IMS__A_20040703T205338, product: SLC, driver: ESA
-        'asar': os.path.join(testdir, 'ASA_IMS_1PNESA20040703_205338_000000182028_00172_12250_00001672562030318361237.N1'),
+        'asar': os.path.join(testdir,
+                             'ASA_IMS_1PNESA20040703_205338_000000182028_00172_12250_00001672562030318361237.N1'),
         # ERS1_IMP__A_19960808T205906, product: PRI, driver: ESA
         'ers1_esa': os.path.join(testdir, 'SAR_IMP_1PXESA19960808_205906_00000017G158_00458_26498_2615.E1'),
         # ERS1_IMS__D_19951220T024320, product: SLC, driver: CEOS_ERS
@@ -54,3 +56,13 @@ def auxdata_dem_cases():
              ('SRTM 3Sec', ['srtm_39_02.zip']),
              ('TDX90m', ['DEM/N51/E010/TDM1_DEM__30_N51E011.zip'])]
     return cases
+
+
+@pytest.fixture
+def tmp_home(monkeypatch, tmp_path):
+    home = tmp_path / 'tmp_home'
+    home.mkdir()
+    var = 'USERPROFILE' if platform.system() == 'Windows' else 'HOME'
+    monkeypatch.setenv(var, str(home))
+    assert os.path.expanduser('~') == str(home)
+    yield home

--- a/tests/test_examine.py
+++ b/tests/test_examine.py
@@ -3,16 +3,17 @@ import pytest
 from pyroSAR.examine import ExamineSnap, SnapProperties
 
 
-def test_snap_config(tmpdir):
+def test_snap_config(tmpdir, tmp_home):
     conf_snap = ExamineSnap()
     conf = SnapProperties(path=os.path.dirname(conf_snap.etc))
-    tmp_userpath = conf.userpath
-    tmp_tilecache = conf['snap.jai.tileCacheSize']
+    path = os.path.join(os.path.expanduser('~'), '.snap', 'etc', 'snap.properties')
+    assert conf.userpath_properties == path
     conf.userpath = tmpdir
     assert conf.userpath == tmpdir
     with pytest.raises(KeyError):
         conf['foobar'] = tmpdir
-    
+    ###########################################################################
+    # check that the type is preserved when setting values
     conf['snap.jai.tileCacheSize'] = 2048
     assert conf['snap.jai.tileCacheSize'] == 2048
     assert isinstance(conf['snap.jai.tileCacheSize'], int)
@@ -39,6 +40,10 @@ def test_snap_config(tmpdir):
 
     conf = SnapProperties(path=os.path.dirname(conf_snap.etc))
     assert conf['snap.jai.tileCacheSize'] is True
+    ###########################################################################
+    # check that a path can correctly be written and read
+    conf = SnapProperties(path=os.path.dirname(conf_snap.etc))
+    conf['snap.userdir'] = str(tmpdir / '.snap')
     
-    conf.userpath = tmp_userpath
-    conf['snap.jai.tileCacheSize'] = tmp_tilecache
+    conf = SnapProperties(path=os.path.dirname(conf_snap.etc))
+    assert conf['snap.userdir'] == str(tmpdir / '.snap')


### PR DESCRIPTION
Colons are escaped by SNAP thus writing Windows paths like `C\:\\`. This case was not considered yet.