### PR TITLE
[DEMHandler] apply file lock to VRTs

### DIFF
--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -478,7 +478,7 @@ class DEMHandler:
     @staticmethod
     def __buildvrt(tiles, vrtfile, pattern, vsi, extent, src_nodata=None,
                    dst_nodata=None, hide_nodata=False, resolution=None,
-                   tap=True, dst_datatype=None):
+                   tap=True, dst_datatype=None, lock_timeout=600):
         """
         Build a VRT mosaic from DEM tiles. The VRT is cropped to the specified `extent` but the pixel grid
         of the source files is preserved and no resampling/shifting is applied.
@@ -510,6 +510,8 @@ class DEMHandler:
         dst_datatype: int or str or None
             the VRT data type as supported by :class:`spatialist.raster.Dtype`.
             Default None: use the same data type as the source files.
+        lock_timeout: int
+            how long to wait to acquire a lock on `vrtfile`?
         
         Returns
         -------
@@ -534,14 +536,16 @@ class DEMHandler:
             opts['VRTNodata'] = dst_nodata
         opts['outputBounds'] = (extent['xmin'], extent['ymin'],
                                 extent['xmax'], extent['ymax'])
-        gdalbuildvrt(src=locals, dst=vrtfile, **opts)
-        if dst_datatype is not None:
-            datatype = Dtype(dst_datatype).gdalstr
-            tree = etree.parse(source=vrtfile)
-            band = tree.find(path='VRTRasterBand')
-            band.attrib['dataType'] = datatype
-            tree.write(file=vrtfile, pretty_print=True,
-                       xml_declaration=False, encoding='utf-8')
+        with Lock(vrtfile, timeout=lock_timeout):
+            if not os.path.isfile(vrtfile):
+                gdalbuildvrt(src=locals, dst=vrtfile, **opts)
+                if dst_datatype is not None:
+                    datatype = Dtype(dst_datatype).gdalstr
+                    tree = etree.parse(source=vrtfile)
+                    band = tree.find(path='VRTRasterBand')
+                    band.attrib['dataType'] = datatype
+                    tree.write(file=vrtfile, pretty_print=True,
+                               xml_declaration=False, encoding='utf-8')
     
     def __commonextent(self, buffer=None):
         """
@@ -1057,7 +1061,7 @@ class DEMHandler:
             bounding box of the geometries is expanded so that the coordinates are
             multiples of the tile size of the respective DEM option.
         lock_timeout: int
-            how long to wait to acquire a lock on downloaded files?
+            how long to wait to acquire a lock on the downloaded files and `vrt`?
         
         Returns
         -------
@@ -1153,7 +1157,8 @@ class DEMHandler:
                             src_nodata=src_nodata, dst_nodata=dst_nodata,
                             hide_nodata=True,
                             resolution=resolution,
-                            tap=tap, dst_datatype=datatype)
+                            tap=tap, dst_datatype=datatype,
+                            lock_timeout=lock_timeout)
         else:
             return locals
     


### PR DESCRIPTION
This ensures parallel processes may not modify the same VRT file.