### PR TITLE
[S1.OSV] fixed bug in searching STEP repository

### DIFF
--- a/pyroSAR/S1/auxil.py
+++ b/pyroSAR/S1/auxil.py
@@ -1,7 +1,7 @@
 ###############################################################################
 # general utilities for Sentinel-1
 
-# Copyright (c) 2016-2023, the pyroSAR Developers.
+# Copyright (c) 2016-2024, the pyroSAR Developers.
 
 # This file is part of the pyroSAR Project. It is subject to the
 # license terms in the LICENSE.txt file found in the top-level
@@ -231,6 +231,7 @@ class OSV(object):
             sensor = [sensor]
         
         files = []
+        date_search_final = datetime(year=stop.year, month=stop.month, day=1)
         for sens in sensor:
             date_search = datetime(year=start.year,
                                    month=start.month,
@@ -258,7 +259,7 @@ class OSV(object):
                         files.append({'filename': file,
                                       'href': url_sub + '/' + file + '.zip',
                                       'auth': None})
-                    if start2 >= stop:
+                    if date_search == date_search_final:
                         busy = False
                 date_search += relativedelta(months=1)
                 if date_search > datetime.now():
@@ -391,7 +392,7 @@ class OSV(object):
              - 'S1A'
              - 'S1B'
              - ['S1A', 'S1B']
-        osvtype: str or list[str]
+        osvtype: str
             the type of orbit files required
         start: str or None
             the date to start searching for files in format YYYYmmddTHHMMSS


### PR DESCRIPTION
The OSV files on https://step.esa.int/auxdata/orbits/Sentinel-1/ are sorted by year and month. `S1.OSV.catch` used to stop searching if the start date of one file on a month's folder (URL) exceeded the defined stop date. In some cases however, the right file would be found in the next month's folder.

```
# scene
S1B_IW_GRDH_1SDV_20210302T061134_20210302T061159_025832_0314AC_52D5.SAFE

# last file for month 2021-02 (not matching the scene)
2021/02/S1B_OPER_AUX_POEORB_OPOD_20210323T111606_V20210302T225942_20210304T005942.EOF.zip

# needed file
2021/03/S1B_OPER_AUX_POEORB_OPOD_20210322T111543_V20210301T225942_20210303T005942.EOF.zip
```