### PR TITLE
enable nested locking

### DIFF
--- a/pyroSAR/ancillary.py
+++ b/pyroSAR/ancillary.py
@@ -413,9 +413,9 @@ class Lock(object):
                 time.sleep(1)
             log.debug(f'acquired {"read" if self.soft else "write"}-lock on {target}')
             self._initialized = True
+        Lock._nesting_levels[self.target] += 1
     
     def __enter__(self):
-        Lock._nesting_levels[self.target] += 1
         return self
     
     def __exit__(self, exc_type, exc_value, traceback):
@@ -478,8 +478,6 @@ class LockCollection(object):
         self.locks = [Lock(x, soft=soft, timeout=timeout) for x in targets]
     
     def __enter__(self):
-        for lock in self.locks:
-            lock.__enter__()
         return self
     
     def __exit__(self, exc_type, exc_value, traceback):

--- a/pyroSAR/ancillary.py
+++ b/pyroSAR/ancillary.py
@@ -371,16 +371,17 @@ class Lock(object):
     def __new__(cls, target, soft=False, timeout=7200):
         target_abs = os.path.abspath(os.path.expanduser(target))
         if target_abs not in cls._instances:
-            log.debug('creating lock instance')
+            log.debug(f'creating lock instance for target {target_abs}')
             instance = super().__new__(cls)
             cls._instances[target_abs] = instance
             cls._nesting_levels[target_abs] = 0
         else:
             if soft != cls._instances[target_abs].soft:
-                msg = 'cannot place nested {}-lock on existing {}-lock'
+                msg = 'cannot place nested {}-lock on existing {}-lock for target {}'
                 vals = ['read', 'write'] if soft else ['write', 'read']
+                vals.append(target_abs)
                 raise RuntimeError(msg.format(*vals))
-            log.debug('reusing lock instance')
+            log.debug(f'reusing lock instance for target {target_abs}')
         return cls._instances[target_abs]
     
     def __init__(self, target, soft=False, timeout=7200):

--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -40,7 +40,7 @@ log = logging.getLogger(__name__)
 
 
 def dem_autoload(geometries, demType, vrt=None, buffer=None, username=None,
-                 password=None, product='dem', crop=True):
+                 password=None, product='dem', crop=True, lock_timeout=600):
     """
     obtain all relevant DEM tiles for selected geometries and optionally mosaic them in a VRT.
 
@@ -195,6 +195,8 @@ def dem_autoload(geometries, demType, vrt=None, buffer=None, username=None,
     
     crop: bool
         crop to the provided geometries (or return the full extent of the DEM tiles)?
+    lock_timeout: int
+        how long to wait to acquire a lock on the downloaded files?
     
     Returns
     -------
@@ -242,7 +244,8 @@ def dem_autoload(geometries, demType, vrt=None, buffer=None, username=None,
                             vrt=vrt,
                             buffer=buffer,
                             product=product,
-                            crop=crop)
+                            crop=crop,
+                            lock_timeout=lock_timeout)
 
 
 def dem_create(src, dst, t_srs=None, tr=None, threads=None,

--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -474,7 +474,7 @@ class DEMHandler:
     @staticmethod
     def __buildvrt(tiles, vrtfile, pattern, vsi, extent, src_nodata=None,
                    dst_nodata=None, hide_nodata=False, resolution=None,
-                   tap=True, dst_datatype=None, lock_timeout=600):
+                   tap=True, dst_datatype=None):
         """
         Build a VRT mosaic from DEM tiles. The VRT is cropped to the specified `extent` but the pixel grid
         of the source files is preserved and no resampling/shifting is applied.
@@ -506,8 +506,6 @@ class DEMHandler:
         dst_datatype: int or str or None
             the VRT data type as supported by :class:`spatialist.raster.Dtype`.
             Default None: use the same data type as the source files.
-        lock_timeout: int
-            how long to wait to acquire a lock on `vrtfile`?
         
         Returns
         -------
@@ -532,21 +530,15 @@ class DEMHandler:
             opts['VRTNodata'] = dst_nodata
         opts['outputBounds'] = (extent['xmin'], extent['ymin'],
                                 extent['xmax'], extent['ymax'])
-        lock = None
-        if os.access(vrtfile, os.W_OK):
-            # lock only if writable, not e.g. vsimem
-            lock = Lock(vrtfile, timeout=lock_timeout)
-        if not os.path.isfile(vrtfile):
-            gdalbuildvrt(src=locals, dst=vrtfile, **opts)
-            if dst_datatype is not None:
-                datatype = Dtype(dst_datatype).gdalstr
-                tree = etree.parse(source=vrtfile)
-                band = tree.find(path='VRTRasterBand')
-                band.attrib['dataType'] = datatype
-                tree.write(file=vrtfile, pretty_print=True,
-                           xml_declaration=False, encoding='utf-8')
-        if lock is not None:
-            lock.remove()
+        
+        gdalbuildvrt(src=locals, dst=vrtfile, **opts)
+        if dst_datatype is not None:
+            datatype = Dtype(dst_datatype).gdalstr
+            tree = etree.parse(source=vrtfile)
+            band = tree.find(path='VRTRasterBand')
+            band.attrib['dataType'] = datatype
+            tree.write(file=vrtfile, pretty_print=True,
+                       xml_declaration=False, encoding='utf-8')
     
     def __commonextent(self, buffer=None):
         """
@@ -1062,7 +1054,7 @@ class DEMHandler:
             bounding box of the geometries is expanded so that the coordinates are
             multiples of the tile size of the respective DEM option.
         lock_timeout: int
-            how long to wait to acquire a lock on the downloaded files and `vrt`?
+            how long to wait to acquire a lock on the downloaded files?
         
         Returns
         -------
@@ -1158,8 +1150,7 @@ class DEMHandler:
                             src_nodata=src_nodata, dst_nodata=dst_nodata,
                             hide_nodata=True,
                             resolution=resolution,
-                            tap=tap, dst_datatype=datatype,
-                            lock_timeout=lock_timeout)
+                            tap=tap, dst_datatype=datatype)
         else:
             return locals
     

--- a/tests/test_ancillary.py
+++ b/tests/test_ancillary.py
@@ -170,3 +170,10 @@ def test_lock(tmpdir):
         with pytest.raises(RuntimeError):
             with Lock(f1, soft=True):
                 assert os.path.isfile(f1 + '.lock')
+    
+    lock = Lock(f1)
+    try:
+        raise RuntimeError
+    except RuntimeError as e:
+        lock.remove(exc_type=type(e))
+    assert os.path.isfile(f1 + '.error')

--- a/tests/test_ancillary.py
+++ b/tests/test_ancillary.py
@@ -171,6 +171,12 @@ def test_lock(tmpdir):
             with Lock(f1, soft=True):
                 assert os.path.isfile(f1 + '.lock')
     
+    with Lock(f1, soft=True):
+        with pytest.raises(RuntimeError):
+            with Lock(f1):
+                assert os.path.isfile(f1 + '.lock')
+    
+    # not using the context manager requires manual lock removal
     lock = Lock(f1)
     try:
         raise RuntimeError


### PR DESCRIPTION
This enables the following, which is useful in situations where a top-level function locks a file and a lower-level function called by it attempts the same.  
```python
f = 'test1.txt'
with Lock(f) as lock1:
    print('hello1')
    with Lock(f) as lock2:
        print('hello2')
```