### PR TITLE
remove upper python version limit and add Windows CI/CD

### DIFF
--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -65,6 +65,8 @@ jobs:
           environment-file: environment-dev.yml
           auto-activate-base: false
       - uses: nyurik/action-setup-postgis@v2
+        with:
+          cached-dir: C:\downloads
       - name: Install ESA SNAP
         run: |
           curl -O https://download.esa.int/step/snap/10_0/installers/esa-snap_sentinel_windows-10.0.0.exe

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: windows-latest
     defaults:
       run:
-        shell: cmd
+        shell: cmd /C CALL {0}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.10
@@ -75,7 +75,7 @@ jobs:
         run: |
           conda install -y python=3.10 pytest
           conda env update --file environment.yml --name base
-      - name: Install package
+      - name: Install pyroSAR
         run: |
           pip install .
       - name: Test with pytest

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -66,10 +66,12 @@ jobs:
           auto-activate-base: false
       - name: Install ESA SNAP
         run: |
+          echo GITHUB_ACTION_PATH: %GITHUB_ACTION_PATH%
           curl -O https://download.esa.int/step/snap/10_0/installers/esa-snap_sentinel_windows-10.0.0.exe
           start /wait esa-snap_sentinel_windows-10.0.0.exe -q -dir %GITHUB_ACTION_PATH%\esa-snap
       - name: Set paths and variables
         run: |
+          echo GITHUB_ACTION_PATH: %GITHUB_ACTION_PATH%
           echo %CONDA%\Scripts >> %GITHUB_PATH%
           echo %GITHUB_ACTION_PATH%\esa-snap\bin >> %GITHUB_PATH%
           echo PROJ_DATA=%CONDA%\share\proj >> %GITHUB_ENV%

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -63,8 +63,8 @@ jobs:
           python-version: '3.10'
       - name: Install ESA SNAP
         run: |
-          curl -O https://download.esa.int/step/snap/10_0/installers/esa-snap_sentinel_windows-10.0.0.exe
-          start /wait esa-snap_sentinel_windows-10.0.0.exe /S /D=$GITHUB_ACTION_PATH\esa-snap
+          powershell -Command "Invoke-WebRequest -Uri 'https://download.esa.int/step/snap/10_0/installers/esa-snap_sentinel_windows-10.0.0.exe' -OutFile 'esa-snap_sentinel_windows-10.0.0.exe'"
+          start /wait esa-snap_sentinel_windows-10.0.0.exe -q -dir $GITHUB_ACTION_PATH\esa-snap
       - name: Set paths and variables
         run: |
           echo "$CONDA\Scripts" >> $GITHUB_PATH

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           activate-environment: ps_test_dev
           auto-update-conda: true
-          python-version: '3.10'
+          python-version: '3.13'
           environment-file: environment-dev.yml
           auto-activate-base: false
       - uses: nyurik/action-setup-postgis@v2
@@ -81,8 +81,6 @@ jobs:
           pip install .
       - name: Test with pytest
         run: |
-          echo %PATH%
-          dir C:\esa-snap\bin
           pytest
         env:
           PGUSER: postgres

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -82,6 +82,7 @@ jobs:
           pip install .
       - name: Test with pytest
         run: |
+          conda install pytest
           pytest
         env:
           PGUSER: postgres

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: windows-latest
     defaults:
       run:
-        shell: cmd
+        shell: cmd /C CALL {0}
     steps:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v3
@@ -66,14 +66,12 @@ jobs:
           auto-activate-base: false
       - name: Install ESA SNAP
         run: |
-          echo GITHUB_ACTION_PATH: %GITHUB_ACTION_PATH%
           curl -O https://download.esa.int/step/snap/10_0/installers/esa-snap_sentinel_windows-10.0.0.exe
-          start /wait esa-snap_sentinel_windows-10.0.0.exe -q -dir %GITHUB_ACTION_PATH%\esa-snap
+          start /wait esa-snap_sentinel_windows-10.0.0.exe -q -dir C:\esa-snap
       - name: Set paths and variables
         run: |
-          echo GITHUB_ACTION_PATH: %GITHUB_ACTION_PATH%
           echo %CONDA%\Scripts >> %GITHUB_PATH%
-          echo %GITHUB_ACTION_PATH%\esa-snap\bin >> %GITHUB_PATH%
+          echo C:\esa-snap\bin >> %GITHUB_PATH%
           echo PROJ_DATA=%CONDA%\share\proj >> %GITHUB_ENV%
       - name: Install pyroSAR
         run: |

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Test with pytest
         run: |
           echo %PATH%
+          dir C:\esa-snap\bin
           pytest
         env:
           PGUSER: postgres

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -28,21 +28,19 @@ jobs:
           echo "$CONDA/bin" >> $GITHUB_PATH
           echo "$GITHUB_ACTION_PATH/esa-snap/bin" >> $GITHUB_PATH
           echo "PROJ_DATA=$CONDA/share/proj" >> $GITHUB_ENV
-      - name: Install dependencies
+      - name: Install python packages
         run: |
-          conda install -y python=3.10
+          conda install -y python=3.10 flake8 pytest coverage
           conda env update --file environment.yml --name base
       - name: Lint with flake8
         run: |
-          conda install flake8
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Install package
+      - name: Install pyroSAR
         run: |
           pip install .
       - name: Test with pytest
         run: |
-          conda install pytest coverage
           coverage run -m pytest
         env:
           PGUSER: postgres
@@ -73,16 +71,15 @@ jobs:
           echo %CONDA%\Scripts >> %GITHUB_PATH%
           echo %GITHUB_ACTION_PATH%\esa-snap\bin >> %GITHUB_PATH%
           echo PROJ_DATA=%CONDA%\share\proj >> %GITHUB_ENV%
-      - name: Install dependencies
+      - name: Install python packages
         run: |
-          conda install -y python=3.10
+          conda install -y python=3.10 pytest
           conda env update --file environment.yml --name base
       - name: Install package
         run: |
           pip install .
       - name: Test with pytest
         run: |
-          conda install pytest
           pytest
         env:
           PGUSER: postgres

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -64,11 +64,7 @@ jobs:
           python-version: '3.10'
           environment-file: environment-dev.yml
           auto-activate-base: false
-      - uses: ireznik/postgis-action@v12
-        with:
-          postgresql version: '16'
-          postgresql password: 'Password12!'
-          postgresql user: 'postgres'
+      - uses: nyurik/action-setup-postgis@v2
       - name: Install ESA SNAP
         run: |
           curl -O https://download.esa.int/step/snap/10_0/installers/esa-snap_sentinel_windows-10.0.0.exe
@@ -88,4 +84,4 @@ jobs:
           pytest
         env:
           PGUSER: postgres
-          PGPASSWORD: Password12!
+          PGPASSWORD: postgres

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -63,7 +63,7 @@ jobs:
           python-version: '3.10'
       - name: Install ESA SNAP
         run: |
-          powershell -Command "Invoke-WebRequest -Uri 'https://download.esa.int/step/snap/10_0/installers/esa-snap_sentinel_windows-10.0.0.exe' -OutFile 'esa-snap_sentinel_windows-10.0.0.exe'"
+          curl -O https://download.esa.int/step/snap/10_0/installers/esa-snap_sentinel_windows-10.0.0.exe
           start /wait esa-snap_sentinel_windows-10.0.0.exe -q -dir $GITHUB_ACTION_PATH\esa-snap
       - name: Set paths and variables
         run: |

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -55,13 +55,6 @@ jobs:
     defaults:
       run:
         shell: cmd /C CALL {0}
-    services:
-      postgres:
-        image: postgis/postgis:16-3.4
-        env:
-          POSTGRES_PASSWORD: Password12!
-        ports:
-          - 5432:5432
     steps:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -55,6 +55,13 @@ jobs:
     defaults:
       run:
         shell: cmd /C CALL {0}
+    services:
+      postgres:
+        image: postgis/postgis:16-3.4
+        env:
+          POSTGRES_PASSWORD: Password12!
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -57,11 +57,13 @@ jobs:
         shell: cmd /C CALL {0}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
-        uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v3
         with:
+          activate-environment: ps_test_dev
           auto-update-conda: true
           python-version: '3.10'
+          environment-file: environment-dev.yml
+          auto-activate-base: false
       - name: Install ESA SNAP
         run: |
           curl -O https://download.esa.int/step/snap/10_0/installers/esa-snap_sentinel_windows-10.0.0.exe
@@ -71,10 +73,6 @@ jobs:
           echo %CONDA%\Scripts >> %GITHUB_PATH%
           echo %GITHUB_ACTION_PATH%\esa-snap\bin >> %GITHUB_PATH%
           echo PROJ_DATA=%CONDA%\share\proj >> %GITHUB_ENV%
-      - name: Install python packages
-        run: |
-          conda install -y python=3.10 pytest
-          conda env update --file environment.yml --name base
       - name: Install pyroSAR
         run: |
           pip install .

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -70,9 +70,9 @@ jobs:
           start /wait esa-snap_sentinel_windows-10.0.0.exe -q -dir C:\esa-snap
       - name: Set paths and variables
         run: |
-          echo %CONDA%\Scripts >> %GITHUB_PATH%
-          echo C:\esa-snap\bin >> %GITHUB_PATH%
-          echo PROJ_DATA=%CONDA%\share\proj >> %GITHUB_ENV%
+          echo %CONDA%\Scripts>> %GITHUB_PATH%
+          echo C:\esa-snap\bin>> %GITHUB_PATH%
+          echo PROJ_DATA=%CONDA%\share\proj>> %GITHUB_ENV%
       - name: Install pyroSAR
         run: |
           pip install .

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: windows-latest
     defaults:
       run:
-        shell: cmd /C CALL {0}
+        shell: cmd
     steps:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -54,6 +54,9 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: cmd
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.10
@@ -64,12 +67,12 @@ jobs:
       - name: Install ESA SNAP
         run: |
           curl -O https://download.esa.int/step/snap/10_0/installers/esa-snap_sentinel_windows-10.0.0.exe
-          start /wait esa-snap_sentinel_windows-10.0.0.exe -q -dir $GITHUB_ACTION_PATH\esa-snap
+          start /wait esa-snap_sentinel_windows-10.0.0.exe -q -dir %GITHUB_ACTION_PATH%\esa-snap
       - name: Set paths and variables
         run: |
-          echo "$CONDA\Scripts" >> $GITHUB_PATH
-          echo "$GITHUB_ACTION_PATH\esa-snap\bin" >> $GITHUB_PATH
-          echo "PROJ_DATA=$CONDA\share\proj" >> $GITHUB_ENV
+          echo %CONDA%\Scripts >> %GITHUB_PATH%
+          echo %GITHUB_ACTION_PATH%\esa-snap\bin >> %GITHUB_PATH%
+          echo PROJ_DATA=%CONDA%\share\proj >> %GITHUB_ENV%
       - name: Install dependencies
         run: |
           conda install -y python=3.10

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -71,6 +71,11 @@ jobs:
           python-version: '3.10'
           environment-file: environment-dev.yml
           auto-activate-base: false
+      - uses: ireznik/postgis-action@v12
+        with:
+          postgresql version: '16'
+          postgresql password: 'Password12!'
+          postgresql user: 'postgres'
       - name: Install ESA SNAP
         run: |
           curl -O https://download.esa.int/step/snap/10_0/installers/esa-snap_sentinel_windows-10.0.0.exe

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -78,6 +78,7 @@ jobs:
           pip install .
       - name: Test with pytest
         run: |
+          echo %PATH%
           pytest
         env:
           PGUSER: postgres

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -3,7 +3,7 @@ name: conda build
 on: [ push ]
 
 jobs:
-  build:
+  build-linux:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -19,7 +19,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: '3.10'
-      - name: install ESA SNAP
+      - name: Install ESA SNAP
         run: |
           wget -nv https://download.esa.int/step/snap/10_0/installers/esa-snap_sentinel_linux-10.0.0.sh
           bash esa-snap_sentinel_linux-10.0.0.sh -q -dir $GITHUB_ACTION_PATH/esa-snap
@@ -30,15 +30,12 @@ jobs:
           echo "PROJ_DATA=$CONDA/share/proj" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
-          : # https://github.com/conda/conda/issues/13560#issuecomment-1992720842
           conda install -y python=3.10
           conda env update --file environment.yml --name base
       - name: Lint with flake8
         run: |
           conda install flake8
-          # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Install package
         run: |
@@ -54,3 +51,35 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ github.token }}
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: '3.10'
+      - name: Install ESA SNAP
+        run: |
+          curl -O https://download.esa.int/step/snap/10_0/installers/esa-snap_sentinel_windows-10.0.0.exe
+          start /wait esa-snap_sentinel_windows-10.0.0.exe /S /D=$GITHUB_ACTION_PATH\esa-snap
+      - name: Set paths and variables
+        run: |
+          echo "$CONDA\Scripts" >> $GITHUB_PATH
+          echo "$GITHUB_ACTION_PATH\esa-snap\bin" >> $GITHUB_PATH
+          echo "PROJ_DATA=$CONDA\share\proj" >> $GITHUB_ENV
+      - name: Install dependencies
+        run: |
+          conda install -y python=3.10
+          conda env update --file environment.yml --name base
+      - name: Install package
+        run: |
+          pip install .
+      - name: Test with pytest
+        run: |
+          pytest
+        env:
+          PGUSER: postgres
+          PGPASSWORD: Password12!

--- a/.github/workflows/conda-install.yml
+++ b/.github/workflows/conda-install.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           activate-environment: ps_test_dev
           auto-update-conda: true
-          python-version: '3.13'
+          python-version: '3.12'
           environment-file: environment-dev.yml
           auto-activate-base: false
       - uses: nyurik/action-setup-postgis@v2

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.8,<3.11
+  - python>=3.8
   - progressbar2
   - numpy<2.0
   - spatialist>=0.12.1

--- a/environment-doc.yml
+++ b/environment-doc.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.8,<3.11
+  - python>=3.8
   - matplotlib
   - numpy<2.0
   - sphinx<7.0  # https://github.com/readthedocs/sphinx_rtd_theme/issues/1463

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.8,<3.11  # https://github.com/kvesteri/sqlalchemy-utils/issues/716
+  - python>=3.8
   - progressbar2
   - numpy<2.0
   - spatialist>=0.12.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "wheel"]
 [project]
 name = "pyroSAR"
 description = "a framework for large-scale SAR satellite data processing"
-requires-python = ">=3.8,<3.11"
+requires-python = ">=3.8"
 license = { file = "LICENSE.txt" }
 maintainers = [
     { name = "John Truckenbrodt", email = "john.truckenbrodt@dlr.de" }


### PR DESCRIPTION
Since version 0.25.0 (via PR https://github.com/johntruckenbrodt/pyroSAR/pull/293) the Python version was limited to `python>=3.6,<3.11` due to an error with `sqlalchemy-utils`.  
The upper limit is now removed and a GitHub Action for Windows testing is added to make sure everything works fine.  
Likely the previous error originated from the way PostgreSQL was installed on Windows. This cannot be reproduced in the GitHub Action and it is thus assumed that everything works fine as long as PostgreSQL is installed properly. See above PR for details.