### PR TITLE
[drivers.identify_many] enable sorting for multicore identification

### DIFF
--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -182,11 +182,11 @@ def identify_many(scenes, pbar=False, sortkey=None, cores=1):
                 progress.update(i + 1)
         if progress is not None:
             progress.finish()
-        if sortkey is not None:
-            idlist.sort(key=operator.attrgetter(sortkey))
     else:
         idlist = multicore(function=handler, multiargs={'scene': scenes},
                            pbar=pbar, cores=cores)
+    if sortkey is not None:
+        idlist.sort(key=operator.attrgetter(sortkey))
     idlist = list(filter(None, idlist))
     return idlist
 


### PR DESCRIPTION
https://github.com/johntruckenbrodt/pyroSAR/pull/331 introduced parallel scene identification but overlooked the `sortkey` argument.  
Now, the scene list created by parallelized identification can also be sorted using the `sortkey` argument.