### PR TITLE
Add Sentinel-1C initials

### DIFF
--- a/pyroSAR/S1/auxil.py
+++ b/pyroSAR/S1/auxil.py
@@ -108,8 +108,8 @@ class OSV(object):
             osvdir = os.path.join(auxdatapath, 'Orbits', 'Sentinel-1')
         self.outdir_poe = os.path.join(osvdir, 'POEORB')
         self.outdir_res = os.path.join(osvdir, 'RESORB')
-        self.pattern = r'S1[AB]_OPER_AUX_(?:POE|RES)ORB_OPOD_[0-9TV_]{48}\.EOF'
-        self.pattern_fine = r'(?P<sensor>S1[AB])_OPER_AUX_' \
+        self.pattern = r'S1[ABCD]_OPER_AUX_(?:POE|RES)ORB_OPOD_[0-9TV_]{48}\.EOF'
+        self.pattern_fine = r'(?P<sensor>S1[ABCD])_OPER_AUX_' \
                             r'(?P<type>(?:POE|RES)ORB)_OPOD_' \
                             r'(?P<publish>[0-9]{8}T[0-9]{6})_V' \
                             r'(?P<start>[0-9]{8}T[0-9]{6})_' \
@@ -392,6 +392,8 @@ class OSV(object):
             
              - 'S1A'
              - 'S1B'
+             - 'S1C'
+             - 'S1D'
              - ['S1A', 'S1B', 'S1C', 'S1D']
         osvtype: str
             the type of orbit files required

--- a/pyroSAR/S1/auxil.py
+++ b/pyroSAR/S1/auxil.py
@@ -281,11 +281,11 @@ class OSV(object):
         else:
             raise RuntimeError("osvtype must be either 'POE' or 'RES'")
         
-        if sensor in ['S1A', 'S1B']:
+        if sensor in ['S1A', 'S1B', 'S1C', 'S1D']:
             query['platformname'] = 'Sentinel-1'
             # filename starts w/ sensor
             query['filename'] = '{}*'.format(sensor)
-        elif sorted(sensor) == ['S1A', 'S1B']:
+        elif sorted(sensor) == ['S1A', 'S1B', 'S1C', 'S1D']:
             query['platformname'] = 'Sentinel-1'
         else:
             raise RuntimeError('unsupported input for parameter sensor')
@@ -392,7 +392,7 @@ class OSV(object):
             
              - 'S1A'
              - 'S1B'
-             - ['S1A', 'S1B']
+             - ['S1A', 'S1B', 'S1C', 'S1D']
         osvtype: str
             the type of orbit files required
         start: str or None

--- a/pyroSAR/datacube_util.py
+++ b/pyroSAR/datacube_util.py
@@ -96,6 +96,8 @@ class Dataset(object):
                              'PSR2': ('ALOS-2', 'PALSAR-2'),
                              'S1A': ('SENTINEL-1', 'C-SAR'),
                              'S1B': ('SENTINEL-1', 'C-SAR'),
+                             'S1C': ('SENTINEL-1', 'C-SAR'),
+                             'S1D': ('SENTINEL-1', 'C-SAR'),
                              'TSX1': ('TERRASAR-X_1', 'SAR'),
                              'TDX1': ('TANDEM-X_1', 'SAR')}
             

--- a/pyroSAR/drivers.py
+++ b/pyroSAR/drivers.py
@@ -1651,6 +1651,8 @@ class SAFE(ID):
     Sensors:
         * S1A
         * S1B
+        * S1C
+        * S1D
 
     References:
         * S1-RS-MDA-52-7443 Sentinel-1 IPF Auxiliary Product Specification

--- a/pyroSAR/gamma/util.py
+++ b/pyroSAR/gamma/util.py
@@ -495,7 +495,7 @@ def correctOSV(id, directory, osvdir=None, osvType='POE', timeout=20,
     if not isinstance(id, ID):
         raise IOError('id must be of type pyroSAR.ID')
     
-    if id.sensor not in ['S1A', 'S1B']:
+    if id.sensor not in ['S1A', 'S1B', 'S1C', 'S1D']:
         raise IOError('this method is currently only available for Sentinel-1. Please stay tuned...')
     
     if not os.path.isdir(logpath):
@@ -705,7 +705,7 @@ def geocode(scene, dem, tmpdir, outdir, spacing, scaling='linear', func_geoback=
     scenes = identify_many(scenes)
     ref = scenes[0]
     
-    if ref.sensor not in ['S1A', 'S1B', 'S1C', 'PALSAR-2']:
+    if ref.sensor not in ['S1A', 'S1B', 'S1C', 'S1D', 'PALSAR-2']:
         raise RuntimeError(
             'this function currently only supports Sentinel-1 and PALSAR-2 Path data. Please stay tuned...')
     
@@ -742,7 +742,7 @@ def geocode(scene, dem, tmpdir, outdir, spacing, scaling='linear', func_geoback=
         os.makedirs(path_log)
     
     for scene in scenes:
-        if scene.sensor in ['S1A', 'S1B'] and removeS1BorderNoiseMethod in ['ESA', 'pyroSAR']:
+        if scene.sensor in ['S1A', 'S1B', 'S1C', 'S1D'] and removeS1BorderNoiseMethod in ['ESA', 'pyroSAR']:
             log.info('removing border noise')
             scene.removeGRDBorderNoise(method=removeS1BorderNoiseMethod)
     
@@ -757,7 +757,7 @@ def geocode(scene, dem, tmpdir, outdir, spacing, scaling='linear', func_geoback=
     
     if update_osv:
         for scene in scenes:
-            if scene.sensor in ['S1A', 'S1B']:
+            if scene.sensor in ['S1A', 'S1B', 'S1C', 'S1D']:
                 log.info('updating orbit state vectors')
                 if allow_RES_OSV:
                     osvtype = ['POE', 'RES']
@@ -802,7 +802,7 @@ def geocode(scene, dem, tmpdir, outdir, spacing, scaling='linear', func_geoback=
             images_new.append(out)
         images = images_new
     
-    if scene.sensor in ['S1A', 'S1B']:
+    if scene.sensor in ['S1A', 'S1B', 'S1C', 'S1D']:
         log.info('multilooking')
         groups = groupby(images, 'polarization')
         images = []
@@ -984,7 +984,7 @@ def geocode(scene, dem, tmpdir, outdir, spacing, scaling='linear', func_geoback=
             exporter(data_in=image + '_gamma0-rtc_geo', scale=scale, dtype=2,
                      nodata=dict(zip(('linear', 'db'), nodata))[scale], outdir=outdir)
     
-    if scene.sensor in ['S1A', 'S1B']:
+    if scene.sensor in ['S1A', 'S1B', 'S1C', 'S1D']:
         outname_base = scene.outname_base(extensions=basename_extensions)
         shutil.copyfile(os.path.join(scene.scene, 'manifest.safe'),
                         os.path.join(outdir, outname_base + '_manifest.safe'))

--- a/pyroSAR/snap/auxil.py
+++ b/pyroSAR/snap/auxil.py
@@ -528,7 +528,7 @@ def writer(xmlfile, outdir, basename_extensions=None,
         infile = reader.parameters['file']
         try:
             id = identify(infile)
-            if id.sensor in ['S1A', 'S1B']:
+            if id.sensor in ['S1A', 'S1B', 'S1C', 'S1D']:
                 manifest = id.getFileObj(id.findfiles('manifest.safe')[0])
                 basename = id.outname_base(basename_extensions)
                 basename = '{0}_manifest.safe'.format(basename)

--- a/pyroSAR/snap/util.py
+++ b/pyroSAR/snap/util.py
@@ -331,7 +331,7 @@ def geocode(infile, outdir, t_srs=4326, spacing=20, polarizations='all', shapefi
         last = read
         ############################################
         # Remove-GRD-Border-Noise node configuration
-        if id.sensor in ['S1A', 'S1B'] and id.product == 'GRD' and removeS1BorderNoise:
+        if id.sensor in ['S1A', 'S1B', 'S1C', 'S1D'] and id.product == 'GRD' and removeS1BorderNoise:
             bn = parse_node('Remove-GRD-Border-Noise')
             workflow.insert_node(bn, before=last.id)
             bn.parameters['selectedPolarisations'] = polarizations
@@ -357,7 +357,7 @@ def geocode(infile, outdir, t_srs=4326, spacing=20, polarizations='all', shapefi
         last = cal
         ############################################
         # ThermalNoiseRemoval node configuration
-        if id.sensor in ['S1A', 'S1B'] and removeS1ThermalNoise:
+        if id.sensor in ['S1A', 'S1B', 'S1C', 'S1D'] and removeS1ThermalNoise:
             tn = parse_node('ThermalNoiseRemoval')
             workflow.insert_node(tn, before=last.id)
             tn.parameters['selectedPolarisations'] = polarizations
@@ -746,7 +746,7 @@ def noise_power(infile, outdir, polarizations, spacing, t_srs, refarea='sigma0',
     
     id = identify(infile)
     
-    if id.sensor not in ['S1A', 'S1B']:
+    if id.sensor not in ['S1A', 'S1B', 'S1C', 'S1D']:
         raise RuntimeError('this function is for Sentinel-1 only')
     
     os.makedirs(outdir, exist_ok=True)


### PR DESCRIPTION
Sentinel-1C appears to be sending data and so it would be very nice to still be able to use `pyroSAR` with the new products as well.

I have simply replaced every occurrence of `['S1A','S1B']`. I think the whole point of these missions is to have standardized data products which means things should run exactly the same.