### PR TITLE
Add support for EPSG:3031 in envidict

### DIFF
--- a/pyroSAR/gamma/auxil.py
+++ b/pyroSAR/gamma/auxil.py
@@ -204,8 +204,27 @@ class ISPPar(object):
                                    str(abs(float(self.post_lon))),
                                    str(abs(float(self.post_lat))),
                                    'WGS-84', 'units=Degrees']
+            elif (
+                self.DEM_projection == 'PS'
+                and self.projection_name == 'WGS 84 / Antarctic Polar Stereographic'
+            ):
+                out['map_info'] = [
+                    'WGS 84 / Antarctic Polar Stereographic',
+                    '1.0000',
+                    '1.0000',
+                    self.corner_east - (abs(self.post_east) / 2),
+                    self.corner_north + (abs(self.post_north) / 2),
+                    str(abs(float(self.post_east))),
+                    str(abs(float(self.post_north))),
+                    'WGS-84',
+                    'units=Meters',
+                ]
             else:
-                raise RuntimeError('unsupported projection: {}'.format(self.DEM_projection))
+                raise RuntimeError(
+                    'unsupported projection: {}. To resolve, create an ENVI map info output for this projection in the envidict function of the ISPPar class.'.format(
+                        self.DEM_projection
+                    )
+                )
         return out
 
 

--- a/pyroSAR/gamma/auxil.py
+++ b/pyroSAR/gamma/auxil.py
@@ -209,7 +209,7 @@ class ISPPar(object):
                 and self.projection_name == 'WGS 84 / Antarctic Polar Stereographic'
             ):
                 out['map_info'] = [
-                    'WGS 84 / Antarctic Polar Stereographic',
+                    'EPSG:3031 - WGS 84 / Antarctic Polar Stereographic',
                     '1.0000',
                     '1.0000',
                     self.corner_east - (abs(self.post_east) / 2),

--- a/pyroSAR/gamma/auxil.py
+++ b/pyroSAR/gamma/auxil.py
@@ -36,12 +36,12 @@ class ISPPar(object):
 
     The values are converted to native Python types, while unit identifiers like 'dB' or 'Hz' are removed.
     Please see the GAMMA reference manual for further information on the actual file format.
-    
+
     Parameters
     ----------
     filename: str
         the GAMMA parameter file
-    
+
     Examples
     --------
     >>> from pyroSAR.gamma import ISPPar
@@ -50,16 +50,16 @@ class ISPPar(object):
     ...     print(par.keys) # print all parameter names
     ...     for key, value in par.envidict().items():
     ...         print('{0}: {1}'.format(key, value)) # print the ENVI HDR compliant metadata
-    
+
     Attributes
     ----------
     keys: list
         the names of all parameters
     """
-    
-    _re_kv_pair = re.compile(r'^(\w+):\s*(.+)\s*')
-    _re_float_literal = re.compile(r'^[+-]?(?:(\d*\.\d+)|(\d+\.?))(?:[Ee][+-]?\d+)?')
-    
+
+    _re_kv_pair = re.compile(r"^(\w+):\s*(.+)\s*")
+    _re_float_literal = re.compile(r"^[+-]?(?:(\d*\.\d+)|(\d+\.?))(?:[Ee][+-]?\d+)?")
+
     def __init__(self, filename):
         """Parses an ISP parameter file from disk.
 
@@ -67,30 +67,30 @@ class ISPPar(object):
             filename: The filename or file object representing the ISP parameter file.
         """
         if isinstance(filename, str):
-            par_file = open(filename, 'r')
+            par_file = open(filename, "r")
         else:
             par_file = filename
-        
-        self.keys = ['filetype']
-        
+
+        self.keys = ["filetype"]
+
         try:
-            content = par_file.read().split('\n')
+            content = par_file.read().split("\n")
         except UnicodeDecodeError:
-            par_file = codecs.open(filename, 'r', encoding='utf-8', errors='ignore')
+            par_file = codecs.open(filename, "r", encoding="utf-8", errors="ignore")
             content = par_file.read()
             printable = set(string.printable)
             content = filter(lambda x: x in printable, content)
-            content = ''.join(list(content)).split('\n')
+            content = "".join(list(content)).split("\n")
         finally:
             par_file.close()
-        
-        if 'Image Parameter File' in content[0]:
-            setattr(self, 'filetype', 'isp')
-        elif 'DEM/MAP parameter file' in content[0]:
-            setattr(self, 'filetype', 'dem')
+
+        if "Image Parameter File" in content[0]:
+            setattr(self, "filetype", "isp")
+        elif "DEM/MAP parameter file" in content[0]:
+            setattr(self, "filetype", "dem")
         else:
-            setattr(self, 'filetype', 'unknown')
-        
+            setattr(self, "filetype", "unknown")
+
         for line in content:
             match = ISPPar._re_kv_pair.match(line)
             if not match:
@@ -121,98 +121,146 @@ class ISPPar(object):
             self.keys.append(key)
             setattr(self, key, value)
 
-        if hasattr(self, 'date'):
+        if hasattr(self, "date"):
             try:
-                self.date = '{}-{:02d}-{:02d}T{:02d}:{:02d}:{:02f}'.format(*self.date)
+                self.date = "{}-{:02d}-{:02d}T{:02d}:{:02d}:{:02f}".format(*self.date)
             except:
                 # if only date available
-                self.date = '{}-{:02d}-{:02d}'.format(*self.date)
-    
+                self.date = "{}-{:02d}-{:02d}".format(*self.date)
+
     def __enter__(self):
         return self
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         return
-    
+
     def __getattr__(self, item):
         # will only be run if object has no attribute item
         raise AttributeError("parameter file has no attribute '{}'".format(item))
-    
+
     def __str__(self):
         maxlen = len(max(self.keys, key=len)) + 1
-        return '\n'.join(['{key}:{sep}{value}'.format(key=key,
-                                                      sep=(maxlen - len(key)) * ' ',
-                                                      value=getattr(self, key)) for key in self.keys])
-    
+        return "\n".join(
+            [
+                "{key}:{sep}{value}".format(
+                    key=key, sep=(maxlen - len(key)) * " ", value=getattr(self, key)
+                )
+                for key in self.keys
+            ]
+        )
+
     def envidict(self, nodata=None):
         """
         export relevant metadata to an ENVI HDR file compliant format
-        
+
         Parameters
         ----------
         nodata: int, float or None
             a no data value to write to the HDR file via attribute 'data ignore value'
-        
+
         Returns
         -------
         dict
             a dictionary containing attributes translated to ENVI HDR naming
         """
-        out = dict(bands=1,
-                   header_offset=0,
-                   file_type='ENVI Standard',
-                   interleave='bsq',
-                   sensor_type='Unknown',
-                   byte_order=1,
-                   wavelength_units='Unknown')
-        
-        if hasattr(self, 'date'):
-            out['acquisition_time'] = self.date + 'Z'
-        
-        out['samples'] = getattr(self, union(['width', 'range_samples', 'samples'], self.keys)[0])
-        out['lines'] = getattr(self, union(['nlines', 'azimuth_lines', 'lines'], self.keys)[0])
-        
-        dtypes_lookup = {'FCOMPLEX': 6, 'FLOAT': 4, 'REAL*4': 4, 'INTEGER*2': 2, 'SHORT': 12}
-        dtype = getattr(self, union(['data_format', 'image_format'], self.keys)[0])
-        
+        out = dict(
+            bands=1,
+            header_offset=0,
+            file_type="ENVI Standard",
+            interleave="bsq",
+            sensor_type="Unknown",
+            byte_order=1,
+            wavelength_units="Unknown",
+        )
+
+        if hasattr(self, "date"):
+            out["acquisition_time"] = self.date + "Z"
+
+        out["samples"] = getattr(
+            self, union(["width", "range_samples", "samples"], self.keys)[0]
+        )
+        out["lines"] = getattr(
+            self, union(["nlines", "azimuth_lines", "lines"], self.keys)[0]
+        )
+
+        dtypes_lookup = {
+            "FCOMPLEX": 6,
+            "FLOAT": 4,
+            "REAL*4": 4,
+            "INTEGER*2": 2,
+            "SHORT": 12,
+        }
+        dtype = getattr(self, union(["data_format", "image_format"], self.keys)[0])
+
         if dtype not in dtypes_lookup.keys():
-            raise TypeError('unsupported data type: {}'.format(dtype))
-        
-        out['data_type'] = dtypes_lookup[dtype]
-        
+            raise TypeError("unsupported data type: {}".format(dtype))
+
+        out["data_type"] = dtypes_lookup[dtype]
+
         if nodata is not None:
-            out['data_ignore_value'] = nodata
-        
-        if out['data_type'] == 6:
-            out['complex_function'] = 'Power'
+            out["data_ignore_value"] = nodata
+
+        if out["data_type"] == 6:
+            out["complex_function"] = "Power"
         # projections = ['AEAC', 'EQA', 'LCC', 'LCC2', 'OMCH', 'PC', 'PS', 'SCH', 'TM', 'UTM']
         # the corner coordinates are shifted by 1/2 pixel to the Northwest since GAMMA pixel
         # coordinates are defined for the pixel center while in ENVI it is the upper left
-        if hasattr(self, 'DEM_projection'):
-            if self.DEM_projection == 'UTM':
-                hem = 'North' if float(self.false_northing) == 0 else 'South'
-                out['map_info'] = ['UTM', '1.0000', '1.0000',
-                                   self.corner_east - (abs(self.post_east) / 2),
-                                   self.corner_north + (abs(self.post_north) / 2),
-                                   str(abs(float(self.post_east))),
-                                   str(abs(float(self.post_north))),
-                                   self.projection_zone, hem, 'WGS-84', 'units=Meters']
-            elif self.DEM_projection == 'EQA':
-                out['map_info'] = ['Geographic Lat/Lon', '1.0000', '1.0000',
-                                   self.corner_lon - (abs(self.post_lon) / 2),
-                                   self.corner_lat + (abs(self.post_lat) / 2),
-                                   str(abs(float(self.post_lon))),
-                                   str(abs(float(self.post_lat))),
-                                   'WGS-84', 'units=Degrees']
+        if hasattr(self, "DEM_projection"):
+            if self.DEM_projection == "UTM":
+                hem = "North" if float(self.false_northing) == 0 else "South"
+                out["map_info"] = [
+                    "UTM",
+                    "1.0000",
+                    "1.0000",
+                    self.corner_east - (abs(self.post_east) / 2),
+                    self.corner_north + (abs(self.post_north) / 2),
+                    str(abs(float(self.post_east))),
+                    str(abs(float(self.post_north))),
+                    self.projection_zone,
+                    hem,
+                    "WGS-84",
+                    "units=Meters",
+                ]
+            elif self.DEM_projection == "EQA":
+                out["map_info"] = [
+                    "Geographic Lat/Lon",
+                    "1.0000",
+                    "1.0000",
+                    self.corner_lon - (abs(self.post_lon) / 2),
+                    self.corner_lat + (abs(self.post_lat) / 2),
+                    str(abs(float(self.post_lon))),
+                    str(abs(float(self.post_lat))),
+                    "WGS-84",
+                    "units=Degrees",
+                ]
+            elif (
+                self.DEM_projection == "PS"
+                and self.projection_name == "WGS 84 / Antarctic Polar Stereographic"
+            ):
+                out["map_info"] = [
+                    "WGS 84 / Antarctic Polar Stereographic",
+                    "1.0000",
+                    "1.0000",
+                    self.corner_east - (abs(self.post_east) / 2),
+                    self.corner_north + (abs(self.post_north) / 2),
+                    str(abs(float(self.post_east))),
+                    str(abs(float(self.post_north))),
+                    "WGS-84",
+                    "units=Meters",
+                ]
             else:
-                raise RuntimeError('unsupported projection: {}'.format(self.DEM_projection))
+                raise RuntimeError(
+                    "unsupported projection: {}. To resolve, create an ENVI map info output for this projection in the envidict function of the ISPPar class.".format(
+                        self.DEM_projection
+                    )
+                )
         return out
 
 
 def par2hdr(parfile, hdrfile, modifications=None, nodata=None):
     """
     Create an ENVI HDR file from a GAMMA PAR file
-    
+
     Parameters
     ----------
     parfile: str
@@ -226,20 +274,20 @@ def par2hdr(parfile, hdrfile, modifications=None, nodata=None):
 
     Returns
     -------
-    
+
     Examples
     --------
     >>> from pyroSAR.gamma.auxil import par2hdr
     >>> par2hdr('dem_seg.par', 'inc.hdr')
     # write a HDR file for byte data based on a parfile of float data
     >>> par2hdr('dem_seg.par', 'ls_map.hdr', modifications={'data_type': 1})
-    
+
     See Also
     --------
     :class:`spatialist.envi.HDRobject`
     :func:`spatialist.envi.hdr`
     """
-    
+
     with ISPPar(parfile) as par:
         items = par.envidict(nodata)
         if modifications is not None:
@@ -250,46 +298,73 @@ def par2hdr(parfile, hdrfile, modifications=None, nodata=None):
 class UTM(object):
     """
     convert a gamma parameter file corner coordinate from EQA to UTM
-    
+
     Parameters
     ----------
     parfile: str
         the GAMMA parameter file to read the coordinate from
-    
+
     Example
     -------
-    
+
     >>> from pyroSAR.gamma import UTM
     >>> print(UTM('gamma.par').zone)
     """
-    
+
     def __init__(self, parfile):
         par = ISPPar(parfile)
-        inlist = ['WGS84', 1, 'EQA', par.corner_lon, par.corner_lat, '', 'WGS84', 1, 'UTM', '']
+        inlist = [
+            "WGS84",
+            1,
+            "EQA",
+            par.corner_lon,
+            par.corner_lat,
+            "",
+            "WGS84",
+            1,
+            "UTM",
+            "",
+        ]
         inlist = map(str, inlist)
-        proc = sp.Popen(['coord_trans'], stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE,
-                        universal_newlines=True, shell=False)
-        out, err = proc.communicate(''.join([x + '\n' for x in inlist]))
-        out = [x for x in filter(None, out.split('\n')) if ':' in x]
-        
+        proc = sp.Popen(
+            ["coord_trans"],
+            stdin=sp.PIPE,
+            stdout=sp.PIPE,
+            stderr=sp.PIPE,
+            universal_newlines=True,
+            shell=False,
+        )
+        out, err = proc.communicate("".join([x + "\n" for x in inlist]))
+        out = [x for x in filter(None, out.split("\n")) if ":" in x]
+
         self.meta = dict()
         for line in out:
-            key, value = re.split(r'\s*:\s*', line)
+            key, value = re.split(r"\s*:\s*", line)
             value = value.split()
             value = map(parse_literal, value) if len(value) > 1 else value[0]
             self.meta[key] = value
         try:
-            self.zone, self.northing, self.easting, self.altitude = \
-                self.meta['UTM zone/northing/easting/altitude (m)']
+            self.zone, self.northing, self.easting, self.altitude = self.meta[
+                "UTM zone/northing/easting/altitude (m)"
+            ]
         except KeyError:
-            self.zone, self.northing, self.easting = \
-                self.meta['UTM zone/northing/easting (m)']
+            self.zone, self.northing, self.easting = self.meta[
+                "UTM zone/northing/easting (m)"
+            ]
 
 
-def process(cmd, outdir=None, logfile=None, logpath=None, inlist=None, void=True, shellscript=None):
+def process(
+    cmd,
+    outdir=None,
+    logfile=None,
+    logpath=None,
+    inlist=None,
+    void=True,
+    shellscript=None,
+):
     """
     wrapper function to execute GAMMA commands via module :mod:`subprocess`
-    
+
     Parameters
     ----------
     cmd: list[str]
@@ -307,7 +382,7 @@ def process(cmd, outdir=None, logfile=None, logpath=None, inlist=None, void=True
         return the stdout and stderr messages?
     shellscript: str
         a file to write the GAMMA commands to in shell format
-    
+
     Returns
     -------
     tuple of str or None
@@ -316,47 +391,68 @@ def process(cmd, outdir=None, logfile=None, logpath=None, inlist=None, void=True
     if logfile is not None:
         log = logfile
     else:
-        log = os.path.join(logpath, os.path.basename(cmd[0]) + '.log') if logpath else None
+        log = (
+            os.path.join(logpath, os.path.basename(cmd[0]) + ".log")
+            if logpath
+            else None
+        )
     gamma_home = ExamineGamma().home
     if shellscript is not None:
         if not os.path.isfile(shellscript):
             # create an empty file
-            with open(shellscript, 'w') as init:
+            with open(shellscript, "w") as init:
                 pass
-        line = ' '.join([str(x) for x in dissolve(cmd)])
+        line = " ".join([str(x) for x in dissolve(cmd)])
         if inlist is not None:
-            line += ' <<< $"{}"'.format('\n'.join([str(x) for x in inlist]) + '\n')
-        with open(shellscript, 'r+') as sh:
+            line += ' <<< $"{}"'.format("\n".join([str(x) for x in inlist]) + "\n")
+        with open(shellscript, "r+") as sh:
             if outdir is not None:
                 content = sh.read()
                 sh.seek(0)
-                is_new = re.search('this script was created automatically by pyroSAR', content) is None
+                is_new = (
+                    re.search(
+                        "this script was created automatically by pyroSAR", content
+                    )
+                    is None
+                )
                 if is_new:
-                    ts = datetime.now().strftime('%a %b %d %H:%M:%S %Y')
-                    sh.write('# this script was created automatically by pyroSAR on {}\n\n'.format(ts))
-                    sh.write('export base={}\n'.format(outdir))
-                    sh.write('export GAMMA_HOME={}\n\n'.format(gamma_home))
+                    ts = datetime.now().strftime("%a %b %d %H:%M:%S %Y")
+                    sh.write(
+                        "# this script was created automatically by pyroSAR on {}\n\n".format(
+                            ts
+                        )
+                    )
+                    sh.write("export base={}\n".format(outdir))
+                    sh.write("export GAMMA_HOME={}\n\n".format(gamma_home))
                     sh.write(content)
-                line = line.replace(outdir, '$base').replace(gamma_home, '$GAMMA_HOME')
+                line = line.replace(outdir, "$base").replace(gamma_home, "$GAMMA_HOME")
             sh.seek(0, 2)  # set pointer to the end of the file
-            sh.write(line + '\n\n')
-    
+            sh.write(line + "\n\n")
+
     # create an environment containing the locations of all GAMMA submodules to be passed to the subprocess calls
     gammaenv = os.environ.copy()
-    gammaenv['GAMMA_HOME'] = gamma_home
-    out, err = run([ExamineGamma().gdal_config, '--datadir'], void=False)
-    gammaenv['GDAL_DATA'] = out.strip()
-    for module in ['DIFF', 'DISP', 'IPTA', 'ISP', 'LAT']:
-        loc = os.path.join(gammaenv['GAMMA_HOME'], module)
+    gammaenv["GAMMA_HOME"] = gamma_home
+    out, err = run([ExamineGamma().gdal_config, "--datadir"], void=False)
+    gammaenv["GDAL_DATA"] = out.strip()
+    for module in ["DIFF", "DISP", "IPTA", "ISP", "LAT"]:
+        loc = os.path.join(gammaenv["GAMMA_HOME"], module)
         if os.path.isdir(loc):
-            gammaenv[module + '_HOME'] = loc
-            for submodule in ['bin', 'scripts']:
+            gammaenv[module + "_HOME"] = loc
+            for submodule in ["bin", "scripts"]:
                 subloc = os.path.join(loc, submodule)
                 if os.path.isdir(subloc):
-                    gammaenv['PATH'] += os.pathsep + subloc
-    
+                    gammaenv["PATH"] += os.pathsep + subloc
+
     # execute the command
-    out, err = run(cmd, outdir=outdir, logfile=log, inlist=inlist, void=False, errorpass=True, env=gammaenv)
+    out, err = run(
+        cmd,
+        outdir=outdir,
+        logfile=log,
+        inlist=inlist,
+        void=False,
+        errorpass=True,
+        env=gammaenv,
+    )
     gammaErrorHandler(out, err)
     if not void:
         return out, err
@@ -365,7 +461,7 @@ def process(cmd, outdir=None, logfile=None, logpath=None, inlist=None, void=True
 class Spacing(object):
     """
     compute multilooking factors and pixel spacings from an ISPPar object for a defined ground range target pixel spacing
-    
+
     Parameters
     ----------
     par: str or ISPPar
@@ -373,12 +469,15 @@ class Spacing(object):
     spacing: int or float
         the target pixel spacing in ground range
     """
-    def __init__(self, par, spacing='automatic'):
+
+    def __init__(self, par, spacing="automatic"):
         # compute ground range pixel spacing
         par = par if isinstance(par, ISPPar) else ISPPar(par)
-        self.groundRangePS = par.range_pixel_spacing / (math.sin(math.radians(par.incidence_angle)))
+        self.groundRangePS = par.range_pixel_spacing / (
+            math.sin(math.radians(par.incidence_angle))
+        )
         # compute initial multilooking factors
-        if spacing == 'automatic':
+        if spacing == "automatic":
             if self.groundRangePS > par.azimuth_pixel_spacing:
                 ratio = self.groundRangePS / par.azimuth_pixel_spacing
                 self.rlks = 1
@@ -397,18 +496,18 @@ class Namespace(object):
         self.__base = basename
         self.__outdir = directory
         self.__reg = []
-    
+
     def __getitem__(self, item):
-        item = str(item).replace('.', '_')
+        item = str(item).replace(".", "_")
         return self.get(item)
-    
+
     def __getattr__(self, item):
         # will only be run if object has no attribute item
-        return '-'
-    
+        return "-"
+
     def appreciate(self, keys):
         """
-        
+
         Parameters
         ----------
         keys: list[str]
@@ -418,13 +517,17 @@ class Namespace(object):
 
         """
         for key in keys:
-            setattr(self, key.replace('.', '_'), os.path.join(self.__outdir, self.__base + '_' + key))
+            setattr(
+                self,
+                key.replace(".", "_"),
+                os.path.join(self.__outdir, self.__base + "_" + key),
+            )
             if key not in self.__reg:
-                self.__reg.append(key.replace('.', '_'))
-    
+                self.__reg.append(key.replace(".", "_"))
+
     def depreciate(self, keys):
         """
-        
+
         Parameters
         ----------
         keys: list[str]
@@ -434,31 +537,31 @@ class Namespace(object):
 
         """
         for key in keys:
-            setattr(self, key.replace('.', '_'), '-')
+            setattr(self, key.replace(".", "_"), "-")
             if key not in self.__reg:
-                self.__reg.append(key.replace('.', '_'))
-    
+                self.__reg.append(key.replace(".", "_"))
+
     def getall(self):
         out = {}
         for key in self.__reg:
             out[key] = getattr(self, key)
         return out
-    
+
     def select(self, selection):
         return [getattr(self, key) for key in selection]
-    
+
     def isregistered(self, key):
         return key in self.__reg
-    
+
     def isappreciated(self, key):
         if self.isregistered(key):
-            if self.get(key) != '-':
+            if self.get(key) != "-":
                 return True
         return False
-    
+
     def isfile(self, key):
         return hasattr(self, key) and os.path.isfile(getattr(self, key))
-    
+
     def get(self, key):
         return getattr(self, key)
 
@@ -466,7 +569,7 @@ class Namespace(object):
 def slc_corners(parfile):
     """
     extract the corner coordinates of a SAR scene
-    
+
     Parameters
     ----------
     parfile: str
@@ -477,16 +580,14 @@ def slc_corners(parfile):
     dict of float
         a dictionary with keys xmin, xmax, ymin, ymax
     """
-    out, err = process(['SLC_corners', parfile], void=False)
+    out, err = process(["SLC_corners", parfile], void=False)
     pts = {}
-    pattern = r'-?[0-9]+\.[0-9]+'
-    for line in out.split('\n'):
-        if line.startswith('min. latitude'):
-            pts['ymin'], pts['ymax'] = [float(x) for x in
-                                        re.findall(pattern, line)]
-        elif line.startswith('min. longitude'):
-            pts['xmin'], pts['xmax'] = [float(x) for x in
-                                        re.findall(pattern, line)]
+    pattern = r"-?[0-9]+\.[0-9]+"
+    for line in out.split("\n"):
+        if line.startswith("min. latitude"):
+            pts["ymin"], pts["ymax"] = [float(x) for x in re.findall(pattern, line)]
+        elif line.startswith("min. longitude"):
+            pts["xmin"], pts["xmax"] = [float(x) for x in re.findall(pattern, line)]
     return pts
 
 
@@ -508,5 +609,5 @@ def do_execute(par, ids, exist_ok):
     bool
         execute the command because (a) not all output files exist or (b) existing files are not allowed
     """
-    all_exist = all([os.path.isfile(par[x]) for x in ids if par[x] != '-'])
+    all_exist = all([os.path.isfile(par[x]) for x in ids if par[x] != "-"])
     return (exist_ok and not all_exist) or not exist_ok


### PR DESCRIPTION
This is in response to https://github.com/johntruckenbrodt/pyroSAR/issues/351

We are currently using a 2023 version of GAMMA (planning to upgrade soon). At this time, the GAMMA .par file does not contain the EPSG code, but it is correctly produced for a DEM in EPSG:3031 (see below). As such, the best solution was to add a case for when envidict encounters `self.DEM_projection=='PS'` and `self.projection_name='WGS 84 / Antarctic Polar Stereographic'`. 

I also added a explicit warning that points the user to the envidict function so that, in future, if a projection isn't supported, they will be able to better understand the traceback.

EPSG:3031 GAMMA DEM parameter file:
```
Gamma DIFF&GEO DEM/MAP parameter file
title: S1A_EW_GRDM_1SDH_20210901T112605_20210901T112710_039487_04AA75_9095
DEM_projection:     PS
data_format:        REAL*4
DEM_hgt_offset:          0.00000
DEM_scale:               1.00000
width:               17830
nlines:              20764
corner_north: -1021152.149   m
corner_east:    -19963.262   m
post_north:    -30.5072846   m
post_east:      30.5072846   m

ellipsoid_name: WGS 84
ellipsoid_ra:        6378137.000   m
ellipsoid_reciprocal_flattening:  298.2572236

datum_name: WGS 84
datum_shift_dx:              0.000   m
datum_shift_dy:              0.000   m
datum_shift_dz:              0.000   m
datum_scale_m:         0.00000e+00
datum_rotation_alpha:  0.00000e+00   arc-sec
datum_rotation_beta:   0.00000e+00   arc-sec
datum_rotation_gamma:  0.00000e+00   arc-sec
datum_country_list: WGS 84

projection_name: WGS 84 / Antarctic Polar Stereographic
projection_zone:                  0
false_easting:                0.000   m
false_northing:               0.000   m
projection_k0:            1.0000000
center_longitude:         0.0000000   decimal degrees
center_latitude:        -71.0000000   decimal degrees
```
