### PR TITLE
support NumPy 2.0

### DIFF
--- a/environment-doc.yml
+++ b/environment-doc.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python>=3.10
   - matplotlib
-  - numpy<2.0
+  - numpy
   - sphinx
   - sphinx_rtd_theme
   - sphinxcontrib-bibtex>=2.2

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - libgdal
   - libspatialite>=5.1.0
   - lxml
-  - numpy<2.0
+  - numpy
   - packaging
   - pillow
   - progressbar2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 geoalchemy2<0.14.0
 lxml
-numpy<2.0
+numpy>=2.0
 packaging
 pillow
 progressbar2
@@ -8,6 +8,6 @@ psycopg2
 pyyaml
 requests
 shapely
-spatialist>=0.16.0
-sqlalchemy>=1.4,<2.0
+spatialist>=0.16.1
 sqlalchemy-utils>=0.37,<0.42
+sqlalchemy>=1.4,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 geoalchemy2<0.14.0
 lxml
-numpy>=2.0
+numpy
 packaging
 pillow
 progressbar2


### PR DESCRIPTION
I would like to use pyroSAR with NumPy >= 2.0, however requirements defined in both pyroSAR and spatialist do not allow for that. With Python 3.10 on Ubuntu 22.04 the dependencies of both spatialist and pyroSAR do no longer require numpy <2.0. I have not tested pyrosar/spatialist with NumPy 2.x, but they install nicely with adjusted requirements.

It may be an option to not pin numpy so both 1 and 2 are possible (Ubuntu 24.04 ships NumPy 1 as system package)....

(See same PR in spatialist)