### PR TITLE
gamma.error: handle subprocess signal kills

### DIFF
--- a/docs/source/api/gamma/error.rst
+++ b/docs/source/api/gamma/error.rst
@@ -1,0 +1,13 @@
+Error handling
+--------------
+
+.. automodule:: pyroSAR.gamma.error
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+    .. autosummary::
+        :nosignatures:
+
+        gammaErrorHandler
+        GammaUnknownError

--- a/docs/source/api/gamma/index.rst
+++ b/docs/source/api/gamma/index.rst
@@ -8,3 +8,4 @@ GAMMA
     auxil
     dem
     api
+    error

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -16,7 +16,7 @@ dependencies:
   - pyyaml
   - requests
   - shapely
-  - spatialist>=0.16.2
+  - spatialist>=0.17.0
   - sqlalchemy>=1.4,<2.0
   - sqlalchemy-utils>=0.37,<0.42
   - coverage

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,6 @@ dependencies:
   - pyyaml
   - requests
   - shapely
-  - spatialist>=0.16.2
+  - spatialist>=0.17.0
   - sqlalchemy>=1.4,<2.0
   - sqlalchemy-utils>=0.37,<0.42

--- a/pyroSAR/examine.py
+++ b/pyroSAR/examine.py
@@ -439,7 +439,7 @@ class ExamineGamma(object):
                                  getattr(self, 'home')).group('version')
         
         try:
-            out, err = run(['which', 'gdal-config'], void=False)
+            returncode, out, err = run(['which', 'gdal-config'], void=False)
             gdal_config = out.strip('\n')
             self.gdal_config = gdal_config
         except sp.CalledProcessError:

--- a/pyroSAR/gamma/auxil.py
+++ b/pyroSAR/gamma/auxil.py
@@ -466,7 +466,7 @@ def process(cmd, outdir=None, logfile=None, logpath=None,
     # execute the command
     returncode, out, err = run(cmd, outdir=outdir, logfile=log, inlist=inlist,
                                void=False, errorpass=True, env=gammaenv)
-    gammaErrorHandler(out, err)
+    gammaErrorHandler(returncode, out, err)
     if not void:
         return out, err
 

--- a/pyroSAR/gamma/auxil.py
+++ b/pyroSAR/gamma/auxil.py
@@ -452,7 +452,7 @@ def process(cmd, outdir=None, logfile=None, logpath=None,
     # create an environment containing the locations of all GAMMA submodules to be passed to the subprocess calls
     gammaenv = os.environ.copy()
     gammaenv['GAMMA_HOME'] = gamma_home
-    out, err = run([ExamineGamma().gdal_config, '--datadir'], void=False)
+    returncode, out, err = run([ExamineGamma().gdal_config, '--datadir'], void=False)
     gammaenv['GDAL_DATA'] = out.strip()
     for module in ['DIFF', 'DISP', 'IPTA', 'ISP', 'LAT']:
         loc = os.path.join(gammaenv['GAMMA_HOME'], module)
@@ -464,7 +464,8 @@ def process(cmd, outdir=None, logfile=None, logpath=None,
                     gammaenv['PATH'] += os.pathsep + subloc
     
     # execute the command
-    out, err = run(cmd, outdir=outdir, logfile=log, inlist=inlist, void=False, errorpass=True, env=gammaenv)
+    returncode, out, err = run(cmd, outdir=outdir, logfile=log, inlist=inlist,
+                               void=False, errorpass=True, env=gammaenv)
     gammaErrorHandler(out, err)
     if not void:
         return out, err

--- a/pyroSAR/gamma/error.py
+++ b/pyroSAR/gamma/error.py
@@ -1,7 +1,7 @@
 ###############################################################################
 # interface for translating GAMMA errors messages into Python error types
 
-# Copyright (c) 2015-2019, the pyroSAR Developers.
+# Copyright (c) 2015-2026, the pyroSAR Developers.
 
 # This file is part of the pyroSAR Project. It is subject to the
 # license terms in the LICENSE.txt file found in the top-level
@@ -13,16 +13,24 @@
 ###############################################################################
 
 import re
+import signal
 
 
-def gammaErrorHandler(out, err):
+def gammaErrorHandler(returncode: int, out: str, err: str) -> None:
     """
-    Function to raise errors in Python. This function is not intended for direct use, but as part of function gamma.util.process
-    Args:
-        out: the stdout message returned by a subprocess call of a gamma command
-        err: the stderr message returned by a subprocess call of a gamma command
+    Function to raise errors in Python. This function is not intended
+    for direct use but as part of function :func:`pyroSAR.gamma.auxil.process`.
+    
+    Parameters
+    ----------
+    returncode:
+        the subprocess return code
+    out:
+        the stdout message returned by a subprocess call of a gamma command
+    err:
+        the stderr message returned by a subprocess call of a gamma command
 
-    Raises: IOError | ValueError | RuntimeError | None
+    Raises: IOError | ValueError | RuntimeError
 
     """
     
@@ -59,26 +67,33 @@ def gammaErrorHandler(out, err):
                    'cannot create ISP image parameter file': OSError}
     
     # check if the error message is known and throw the mapped error from knownErrors accordingly.
-    # Otherwise throw an GammaUnknownError.
-    # The actual message is passed to the error and thus visible for backtracing
-    if len(errormessages) > 0:
-        errormessage = errormessages[-1]
-        err_out = '\n\n'.join([re.sub('ERROR[: ]*', '', x) for x in errormessages])
-        for error in knownErrors:
-            if re.search(error, errormessage):
-                errortype = knownErrors[error]
-                if errortype:
-                    raise errortype(err_out)
-                else:
-                    return
+    # Otherwise raise a RuntimeError if killed by a signal and a GammaUnknownError in all other cases.
+    # The actual message is passed to the error and thus visible for backtracing.
+    if returncode != 0:
+        if len(errormessages) > 0:
+            errormessage = errormessages[-1]
+            err_out = '\n\n'.join([re.sub('ERROR[: ]*', '', x) for x in errormessages])
+            for error in knownErrors:
+                if re.search(error, errormessage):
+                    errortype = knownErrors[error]
+                    if errortype:
+                        raise errortype(err_out)
+                    else:
+                        return
+        else:
+            err_out = f'failed with return code {returncode}'
+            if returncode < 0:
+                # handle signal kills like SIGSEGV (segmentation fault)
+                sig = signal.Signals(-returncode)
+                raise RuntimeError(err_out + f' ({sig.name})')
         raise GammaUnknownError(err_out)
 
 
 class GammaUnknownError(Exception):
     """
     This is a general error, which is raised if the error message is not yet integrated
-    into the known errors of function gammaErrorHandler.
-    If this error occurs the message should be included in function gammaErrorHandler.
+    into the known errors of function :func:`gammaErrorHandler`.
+    If this error occurs, the message should be included in this function.
     """
     
     def __init__(self, errormessage):

--- a/pyroSAR/snap/auxil.py
+++ b/pyroSAR/snap/auxil.py
@@ -108,7 +108,7 @@ def parse_node(name, use_existing=True):
             
             cmd = [gpt, operator, '-h']
             
-            out, err = run(cmd=cmd, void=False)
+            returncode, out, err = run(cmd=cmd, void=False)
             
             if re.search('Unknown operator', out + err):
                 raise RuntimeError("unknown operator '{}'".format(operator))

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ psycopg2
 pyyaml
 requests
 shapely
-spatialist>=0.16.2
+spatialist>=0.17.0
 sqlalchemy-utils>=0.37,<0.42
 sqlalchemy>=1.4,<2.0


### PR DESCRIPTION
.. like segmentation fault (SIGSEGV). Before these were just passed through, now a `RuntimeError` is raised.


Also added the `gamma.error` module to the documentation.