### PR TITLE
[auxdata.DEMHandler] do not allow 'extent=None'

### DIFF
--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -641,7 +641,7 @@ class DEMHandler:
         driver = None
     
     @staticmethod
-    def intrange(extent: EXT | None, step: int) -> tuple[range, range]:
+    def intrange(extent: EXT, step: int) -> tuple[range, range]:
         """
         generate a sequence of integer coordinates marking
         the tie points of the individual DEM tiles.
@@ -658,16 +658,12 @@ class DEMHandler:
         -------
             the integer sequences as (latitude, longitude)
         """
-        if extent is None:
-            lat = range(-90, 90)
-            lon = range(-180, 180)
-        else:
-            lat = range(floor(float(extent['ymin']) / step) * step,
-                        ceil(float(extent['ymax']) / step) * step,
-                        step)
-            lon = range(floor(float(extent['xmin']) / step) * step,
-                        ceil(float(extent['xmax']) / step) * step,
-                        step)
+        lat = range(floor(float(extent['ymin']) / step) * step,
+                    ceil(float(extent['ymax']) / step) * step,
+                    step)
+        lon = range(floor(float(extent['xmin']) / step) * step,
+                    ceil(float(extent['xmax']) / step) * step,
+                    step)
         return lat, lon
     
     def __get_resolution(
@@ -1253,7 +1249,8 @@ class DEMHandler:
                                                   username=username, password=password,
                                                   product=product))
         else:
-            candidates = self.remote_ids(extent=None, dem_type=dem_type,
+            extent = {'xmin': -180, 'xmax': 180, 'ymin': -90, 'ymax': 90}
+            candidates = self.remote_ids(extent=extent, dem_type=dem_type,
                                          username=username, password=password,
                                          product=product)
         
@@ -1335,7 +1332,7 @@ class DEMHandler:
     
     def remote_ids(
             self,
-            extent: EXT | None,
+            extent: EXT,
             dem_type: str,
             product: str = 'dem',
             username: str | None = None,
@@ -1350,7 +1347,7 @@ class DEMHandler:
             the extent of the area of interest with keys xmin, xmax, ymin, ymax
             or `None` to not set any spatial filter.
         dem_type
-            the type fo DEM to be used
+            the type of DEM to be used
         product
             the sub-product to extract from the DEM product. Only needed for DEM options 'Copernicus 30m Global DEM'
             and 'Copernicus 90m Global DEM' and ignored otherwise.

--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -722,7 +722,7 @@ class DEMHandler:
                         if marker is None:
                             del items[items.index(catalog_json)]
                         marker = items[-1]
-                        items = sorted([URL_STAC + '/' + x for x in items])
+                        items = sorted([URL_STAC + '/' + x for x in items if x is not None])
                         URL = None
                         for item in items:
                             if URL is None:

--- a/pyroSAR/auxdata.py
+++ b/pyroSAR/auxdata.py
@@ -597,6 +597,8 @@ class DEMHandler:
         -------
             the common extent of all geometries
         """
+        if self.geometries is None:
+            return self.__extent_global
         ext_new = {}
         for geo in self.geometries:
             if len(ext_new.keys()) == 0:
@@ -639,6 +641,10 @@ class DEMHandler:
         band = None
         dataset = None
         driver = None
+    
+    @property
+    def __extent_global(self) -> EXT:
+        return {'xmin': -180, 'xmax': 180, 'ymin': -90, 'ymax': 90}
     
     @staticmethod
     def intrange(extent: EXT, step: int) -> tuple[range, range]:
@@ -1249,8 +1255,7 @@ class DEMHandler:
                                                   username=username, password=password,
                                                   product=product))
         else:
-            extent = {'xmin': -180, 'xmax': 180, 'ymin': -90, 'ymax': 90}
-            candidates = self.remote_ids(extent=extent, dem_type=dem_type,
+            candidates = self.remote_ids(extent=self.__extent_global, dem_type=dem_type,
                                          username=username, password=password,
                                          product=product)
         
@@ -1277,12 +1282,16 @@ class DEMHandler:
         extent = self.__commonextent(buffer=buffer)
         aop = self.config[dem_type]['area_or_point']
         res = self.__get_resolution(dem_type=dem_type, y=extent['ymin'])
+        
+        # expand the extent to multiples of the DEM tile size
         if not crop:
             f = self.config[dem_type]['tilesize']
             extent['xmin'] = floor(extent['xmin'] / f) * f
             extent['ymin'] = floor(extent['ymin'] / f) * f
             extent['xmax'] = ceil(extent['xmax'] / f) * f
             extent['ymax'] = ceil(extent['ymax'] / f) * f
+        
+        # shift coordinates from upper left corner (area) to center (point)
         if aop == 'point':
             shift_x = res[0] / 2
             shift_y = res[1] / 2


### PR DESCRIPTION
... to fix global processing. `extent=None` was not properly handled in `DEMHandler.remote_ids`. Now, one always has to provide an extent in the methods. `DEMHandler` instead now auto-defines a global extent if there are no geometries defined.