### PR TITLE
improved gamma parsing

### DIFF
--- a/pyroSAR/examine.py
+++ b/pyroSAR/examine.py
@@ -438,6 +438,24 @@ class ExamineGamma(object):
         self.version = re.search('GAMMA_SOFTWARE[-/](?P<version>[0-9]{8})',
                                  getattr(self, 'home')).group('version')
         
+        modules = finder(self.home, [['[A-Z]*']], foldermode=2, recursive=False)
+        for module in modules:
+            module_base = os.path.basename(module)
+            module_home = os.environ.get(f'{module_base}_HOME')
+            if module_home is None:
+                raise RuntimeError(
+                    f"Found GAMMA module '{module_base}', "
+                    f"but environment variable '{module_base}_HOME' "
+                    f"is not set."
+                )
+            else:
+                if self.home not in module_home:
+                    raise RuntimeError(
+                        f"Inconsistent paths in environment variables:\n"
+                        f"GAMMA_HOME: {self.home}\n"
+                        f"{module_base}_HOME: {module_home}"
+                    )
+        
         try:
             returncode, out, err = run(['which', 'gdal-config'], void=False)
             gdal_config = out.strip('\n')

--- a/pyroSAR/gamma/api.py
+++ b/pyroSAR/gamma/api.py
@@ -1,7 +1,7 @@
 ###############################################################################
 # import wrapper for the pyroSAR GAMMA API
 
-# Copyright (c) 2018-2019, the pyroSAR Developers.
+# Copyright (c) 2018-2026, the pyroSAR Developers.
 
 # This file is part of the pyroSAR Project. It is subject to the
 # license terms in the LICENSE.txt file found in the top-level
@@ -13,19 +13,11 @@
 ###############################################################################
 import os
 import sys
-import warnings
 
 from .parser import autoparse
 
-try:
-    autoparse()
-    
-    sys.path.insert(0, os.path.join(os.path.expanduser('~'), '.pyrosar'))
-    
-    try:
-        from gammaparse import *
-    except ImportError:
-        warnings.warn('found a GAMMA installation directory, but module parsing failed')
+autoparse()
 
-except RuntimeError:
-    warnings.warn('could not find GAMMA installation directory; please set the GAMMA_HOME environment variable')
+sys.path.insert(0, os.path.join(os.path.expanduser('~'), '.pyrosar'))
+
+from gammaparse import *

--- a/pyroSAR/gamma/parser.py
+++ b/pyroSAR/gamma/parser.py
@@ -663,7 +663,7 @@ def parse_module(directory: str, outfile: str) -> None:
     Parameters
     ----------
     directory
-        the directory (bin/scripts) of a module containing the commands
+        the module's directory containing subdirectories `bin` and `scripts`
     outfile
         the name of the Python file to write
 

--- a/pyroSAR/gamma/parser.py
+++ b/pyroSAR/gamma/parser.py
@@ -670,23 +670,25 @@ def parse_module(directory: str, outfile: str) -> None:
             try:
                 fun = parse_command(cmd)
             except RuntimeError as e:
-                failed.append('{0}: {1}'.format(basename, str(e)))
+                failed.append(f'{basename}: {str(e)}')
                 continue
             except DeprecationWarning:
                 continue
             except:
-                failed.append('{0}: {1}'.format(basename, 'error yet to be assessed'))
+                failed.append(f'{basename}: error yet to be assessed')
                 continue
             outstring += fun + '\n\n'
+    
+    if len(failed) > 0:
+        info = 'Could not parse the following GAMMA commands:\n{0}\n({1} total)'
+        raise RuntimeError(info.format('\n'.join(failed), len(failed)))
+    
     if len(outstring) > 0:
         if not os.path.isfile(outfile):
             with open(outfile, 'w') as out:
                 out.write('from pyroSAR.gamma.auxil import process\n\n\n')
         with open(outfile, 'a') as out:
             out.write(outstring)
-    if len(failed) > 0:
-        info = 'the following functions could not be parsed:\n{0}\n({1} total)'
-        log.info(info.format('\n'.join(failed), len(failed)))
 
 
 def autoparse() -> None:

--- a/pyroSAR/gamma/parser.py
+++ b/pyroSAR/gamma/parser.py
@@ -704,13 +704,10 @@ def parse_module(directory: str, outfile: str) -> None:
             if basename not in excludes:
                 try:
                     fun = parse_command(cmd)
-                except RuntimeError as e:
-                    failed.append(f'{cmd}: {str(e)}')
-                    continue
                 except DeprecationWarning:
                     continue
-                except:
-                    failed.append(f'{cmd}: error yet to be assessed')
+                except Exception as e:
+                    failed.append(f'{cmd}: {type(e).__name__}({e})')
                     continue
                 outstring += fun + '\n\n'
     

--- a/pyroSAR/gamma/parser.py
+++ b/pyroSAR/gamma/parser.py
@@ -25,7 +25,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def parse_command(command: str, indent: str='    ') -> str:
+def parse_command(command: str, indent: str = '    ') -> str:
     """
     Parse the help text of a GAMMA command to a Python function including a docstring.
     The docstring is in rst format and can thus be parsed by e.g. sphinx.
@@ -50,6 +50,35 @@ def parse_command(command: str, indent: str='    ') -> str:
     command_base = os.path.basename(command)
     proc = sp.Popen(command, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE, universal_newlines=True)
     out, err = proc.communicate()
+    
+    # raise an error if the command cannot be executed normally
+    # 255 is the normal return code of binary executables.
+    # Several scripts return 0.
+    # Some commands unexpectedly return 1 or 2. This is currently being checked with the GAMMA developers.
+    
+    exceptions_returncode = {
+        1: [
+            'kml_map',
+            'kml_pt',
+            'svg_arrow',
+            'svg_map',
+            'svg_poly',
+            'par_Fucheng_SLC',
+            'par_HT1_SLC',
+            'INTF_SLC',
+        ],
+        2: ['vrt2dem']
+    }
+    
+    returncodes = [0, 255]
+    for returncode, commands in exceptions_returncode.items():
+        if command_base in commands:
+            returncodes.append(returncode)
+            break
+    
+    if proc.returncode not in returncodes:
+        raise RuntimeError(f'"{err}" (return code: {proc.returncode})')
+    
     # sometimes the description string is split between stdout and stderr
     # for the following commands stderr contains the usage description line, which is inserted into stdout
     if command_base in ['ras_pt', 'ras_data_pt', 'rasdt_cmap_pt']:
@@ -58,7 +87,7 @@ def parse_command(command: str, indent: str='    ') -> str:
         # for all other commands stderr is just appended to stdout
         out += err
     
-    # raise a warning when the command has been deprecated
+    # raise a warning if the command has been deprecated
     # extract all lines starting and ending with three asterisks
     matches = re.findall(r'^\*{3}\s*(.*?)\s*\*{3}$', out, re.MULTILINE)
     if matches:
@@ -69,9 +98,6 @@ def parse_command(command: str, indent: str='    ') -> str:
         match = re.search(pattern, cleaned)
         if match:
             raise DeprecationWarning(match.group())
-    
-    if re.search(r"Can't locate FILE/Path\.pm in @INC", out):
-        raise RuntimeError('unable to parse Perl script')
     ###########################################
     # fix command-specific inconsistencies in parameter naming
     # in several commands the parameter naming in the usage description line does not match that of the docstring

--- a/pyroSAR/gamma/parser.py
+++ b/pyroSAR/gamma/parser.py
@@ -747,7 +747,7 @@ def autoparse() -> None:
     target = os.path.join(os.path.expanduser('~'), '.pyrosar', 'gammaparse')
     if not os.path.isdir(target):
         os.makedirs(target)
-    for module in finder(home, ['[A-Z]*'], foldermode=2):
+    for module in finder(home, ['[A-Z]*'], foldermode=2, recursive=False):
         outfile = os.path.join(target, os.path.basename(module).lower() + '.py')
         if not os.path.isfile(outfile):
             log.info(f'parsing module {os.path.basename(module)} to {outfile}')

--- a/pyroSAR/gamma/parser.py
+++ b/pyroSAR/gamma/parser.py
@@ -649,9 +649,6 @@ def parse_module(directory: str, outfile: str) -> None:
     >>> parse_module('/cluster/GAMMA_SOFTWARE-20161207/ISP/bin', outname)
     """
     
-    if not os.path.isdir(directory):
-        raise OSError('directory does not exist: {}'.format(directory))
-    
     excludes = [
         'coord_trans',  # doesn't take any parameters and is interactive
         'RSAT2_SLC_preproc',  # takes option flags
@@ -662,22 +659,34 @@ def parse_module(directory: str, outfile: str) -> None:
     ]
     failed = []
     outstring = ''
-    cmds = sorted(finder(directory, [r'^\w+$'], regex=True),
-                  key=lambda s: s.lower())
-    for cmd in cmds:
-        basename = os.path.basename(cmd)
-        if basename not in excludes:
-            try:
-                fun = parse_command(cmd)
-            except RuntimeError as e:
-                failed.append(f'{basename}: {str(e)}')
-                continue
-            except DeprecationWarning:
-                continue
-            except:
-                failed.append(f'{basename}: error yet to be assessed')
-                continue
-            outstring += fun + '\n\n'
+    
+    if not os.path.isdir(directory):
+        raise OSError('directory does not exist: {}'.format(directory))
+    
+    for submodule in ['bin', 'scripts']:
+        log.info(submodule)
+        target = os.path.join(directory, submodule)
+        
+        if not os.path.isdir(target):
+            continue
+        
+        cmds = sorted(finder(target, [r'^\w+$'], regex=True),
+                      key=lambda s: s.lower())
+        
+        for cmd in cmds:
+            basename = os.path.basename(cmd)
+            if basename not in excludes:
+                try:
+                    fun = parse_command(cmd)
+                except RuntimeError as e:
+                    failed.append(f'{basename}: {str(e)}')
+                    continue
+                except DeprecationWarning:
+                    continue
+                except:
+                    failed.append(f'{basename}: error yet to be assessed')
+                    continue
+                outstring += fun + '\n\n'
     
     if len(failed) > 0:
         info = 'Could not parse the following GAMMA commands:\n{0}\n({1} total)'
@@ -716,12 +725,10 @@ def autoparse() -> None:
         outfile = os.path.join(target, os.path.basename(module).lower() + '.py')
         if not os.path.isfile(outfile):
             log.info(f'parsing module {os.path.basename(module)} to {outfile}')
-            for submodule in ['bin', 'scripts']:
-                log.info(submodule)
-                try:
-                    parse_module(os.path.join(module, submodule), outfile)
-                except OSError:
-                    log.info('..does not exist')
+            try:
+                parse_module(module, outfile)
+            except OSError:
+                log.info('..does not exist')
     modules = [re.sub(r'\.py', '', os.path.basename(x))
                for x in finder(target, [r'[a-z]+\.py$'], regex=True)]
     if len(modules) > 0:

--- a/pyroSAR/gamma/parser.py
+++ b/pyroSAR/gamma/parser.py
@@ -679,12 +679,12 @@ def parse_module(directory: str, outfile: str) -> None:
                 try:
                     fun = parse_command(cmd)
                 except RuntimeError as e:
-                    failed.append(f'{basename}: {str(e)}')
+                    failed.append(f'{cmd}: {str(e)}')
                     continue
                 except DeprecationWarning:
                     continue
                 except:
-                    failed.append(f'{basename}: error yet to be assessed')
+                    failed.append(f'{cmd}: error yet to be assessed')
                     continue
                 outstring += fun + '\n\n'
     

--- a/pyroSAR/gamma/parser.py
+++ b/pyroSAR/gamma/parser.py
@@ -630,14 +630,14 @@ def parse_command(command: str, indent: str='    ') -> str:
     return fun
 
 
-def parse_module(bindir: str, outfile: str) -> None:
+def parse_module(directory: str, outfile: str) -> None:
     """
-    parse all Gamma commands of a module to functions and save them to a Python script.
+    parse all GAMMA commands of a module to functions and save them to a Python script.
 
     Parameters
     ----------
-    bindir
-        the `bin` directory of a module containing the commands
+    directory
+        the directory (bin/scripts) of a module containing the commands
     outfile
         the name of the Python file to write
 
@@ -649,19 +649,22 @@ def parse_module(bindir: str, outfile: str) -> None:
     >>> parse_module('/cluster/GAMMA_SOFTWARE-20161207/ISP/bin', outname)
     """
     
-    if not os.path.isdir(bindir):
-        raise OSError('directory does not exist: {}'.format(bindir))
+    if not os.path.isdir(directory):
+        raise OSError('directory does not exist: {}'.format(directory))
     
-    excludes = ['coord_trans',  # doesn't take any parameters and is interactive
-                'RSAT2_SLC_preproc',  # takes option flags
-                'mk_ASF_CEOS_list',  # "cannot create: Directory nonexistent"
-                '2PASS_UNW',  # parameter name inconsistencies
-                'mk_diff_2d',  # takes option flags
-                'gamma_doc'  # opens the Gamma documentation
-                ]
+    excludes = [
+        'coord_trans',  # doesn't take any parameters and is interactive
+        'RSAT2_SLC_preproc',  # takes option flags
+        'mk_ASF_CEOS_list',  # "cannot create: Directory nonexistent"
+        '2PASS_UNW',  # parameter name inconsistencies
+        'mk_diff_2d',  # takes option flags
+        'gamma_doc'  # opens the Gamma documentation
+    ]
     failed = []
     outstring = ''
-    for cmd in sorted(finder(bindir, [r'^\w+$'], regex=True), key=lambda s: s.lower()):
+    cmds = sorted(finder(directory, [r'^\w+$'], regex=True),
+                  key=lambda s: s.lower())
+    for cmd in cmds:
         basename = os.path.basename(cmd)
         if basename not in excludes:
             try:

--- a/pyroSAR/gamma/util.py
+++ b/pyroSAR/gamma/util.py
@@ -41,7 +41,13 @@ import logging
 
 log = logging.getLogger(__name__)
 
-from .api import diff, disp, isp, lat
+from .api import diff, disp, isp
+
+# the LAT module is not necessarily needed by this module
+try:
+    from .api import lat
+except ImportError:
+    pass
 
 
 def calibrate(id, directory, return_fnames=False,

--- a/pyroSAR/gamma/util.py
+++ b/pyroSAR/gamma/util.py
@@ -41,10 +41,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
-try:
-    from .api import diff, disp, isp, lat
-except ImportError:
-    pass
+from .api import diff, disp, isp, lat
 
 
 def calibrate(id, directory, return_fnames=False,

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -1,5 +1,9 @@
 import os
 import pytest
+
+if "GAMMA_HOME" not in os.environ:
+    pytest.skip("GAMMA is not installed", allow_module_level=True)
+
 from pyroSAR.gamma import ISPPar, par2hdr, Namespace, slc_corners, api
 
 
@@ -44,7 +48,7 @@ def test_namespace():
     assert n['dem_seg'] == '-'
 
 
-@pytest.mark.skipif('isp' not in dir(api), reason='requires GAMMA installation with module ISP')
+@pytest.mark.skipif(not hasattr(api, 'isp'), reason='requires GAMMA installation with module ISP')
 def test_slc_corners(testdata):
     print(testdata['dempar'])
     pts = slc_corners(testdata['mlipar'])

--- a/tests/test_gamma_args.py
+++ b/tests/test_gamma_args.py
@@ -1,9 +1,14 @@
+import os
 import pytest
+
+if "GAMMA_HOME" not in os.environ:
+    pytest.skip("GAMMA is not installed", allow_module_level=True)
+
 from pyroSAR.ancillary import getargs
 from pyroSAR.gamma import api
 
 
-@pytest.mark.skipif('diff' not in dir(api), reason='requires GAMMA installation with module DIFF')
+@pytest.mark.skipif(not hasattr(api, 'diff'), reason='requires GAMMA installation with module DIFF')
 def test_args_diff():
     from pyroSAR.gamma.api import diff
     lookup = {
@@ -32,7 +37,7 @@ def test_args_diff():
         assert set(args).issubset(getargs(getattr(diff, command)))
 
 
-@pytest.mark.skipif('disp' not in dir(api), reason='requires GAMMA installation with module DISP')
+@pytest.mark.skipif(not hasattr(api, 'disp'), reason='requires GAMMA installation with module DISP')
 def test_args_disp():
     from pyroSAR.gamma.api import disp
     lookup = {
@@ -43,7 +48,7 @@ def test_args_disp():
         assert set(args).issubset(getargs(getattr(disp, command)))
 
 
-@pytest.mark.skipif('isp' not in dir(api), reason='requires GAMMA installation with module ISP')
+@pytest.mark.skipif(not hasattr(api, 'isp'), reason='requires GAMMA installation with module ISP')
 def test_args_isp():
     from pyroSAR.gamma.api import isp
     lookup = {
@@ -83,7 +88,7 @@ def test_args_isp():
         assert set(args + default).issubset(getargs(getattr(isp, command)))
 
 
-@pytest.mark.skipif('lat' not in dir(api), reason='requires GAMMA installation with module LAT')
+@pytest.mark.skipif(not hasattr(api, 'lat'), reason='requires GAMMA installation with module LAT')
 def test_args_lat():
     from pyroSAR.gamma.api import lat
     lookup = {


### PR DESCRIPTION
This modifies the GAMMA API behavior to make the whole parsing process more transparent and easier to debug.  
Before, it could easily happen that parsing of individual commands failed but the user did not notice this if logging was turned off. This is now prevented by always raising an error if any parsing fails. Also, error handling has largely improved by interpreting command execution error codes and consistently passing error messages.

Interface changes:
- `gamma.parser.parse_module`:
  - renamed `bindir` to `directory`
  - now expects the module directory and not the subdirectories `bin`/`scripts`. The function now loops over those subdirectories

Behavior changes:
- `gamma.api`:
  - raise an error and not a warning if module parsing or import fails
- `gamma.util`:
  - strictly require import of modules `diff`, `disp` and `isp`; `lat` is kept optional because it is not strictly needed
- `gamma.parser.parse_module`:
  - raise an error if commands could not be parsed (instead of just logging an info)
- `gamma.parser.parse_command`:
  - raise an error if the return code of the called command is unexpected
- `examine.ExamineGamma`:
  - strictly check for set environment variables like `DIFF_HOME`