### PR TITLE
[gamma.api] make modules importable even if GAMMA is not installed

### DIFF
--- a/pyroSAR/gamma/api.py
+++ b/pyroSAR/gamma/api.py
@@ -16,8 +16,32 @@ import sys
 
 from .parser import autoparse
 
-autoparse()
 
-sys.path.insert(0, os.path.join(os.path.expanduser('~'), '.pyrosar'))
+# These placeholders allow pyroSAR.gamma modules to be imported when GAMMA
+# is unavailable. They are replaced by the generated modules when parsing
+# succeeds.
+class _UnavailableGammaModule:
+    def __init__(self, module: str) -> None:
+        self.module = module
+    
+    def __getattr__(self, command: str):
+        raise RuntimeError(
+            f"The command '{command}' is not available. "
+            f"Please install GAMMA module '{self.module.upper()}'."
+        )
 
-from gammaparse import *
+
+diff = _UnavailableGammaModule('diff')
+disp = _UnavailableGammaModule('disp')
+isp = _UnavailableGammaModule('isp')
+lat = _UnavailableGammaModule('lat')
+
+try:
+    autoparse()
+    
+    sys.path.insert(0, os.path.join(os.path.expanduser('~'), '.pyrosar'))
+    
+    from gammaparse import *
+
+except (ImportError, OSError, RuntimeError) as e:
+    pass

--- a/pyroSAR/gamma/api.py
+++ b/pyroSAR/gamma/api.py
@@ -36,12 +36,9 @@ disp = _UnavailableGammaModule('disp')
 isp = _UnavailableGammaModule('isp')
 lat = _UnavailableGammaModule('lat')
 
-try:
+if 'GAMMA_HOME' in os.environ:
     autoparse()
     
     sys.path.insert(0, os.path.join(os.path.expanduser('~'), '.pyrosar'))
     
     from gammaparse import *
-
-except (ImportError, OSError, RuntimeError) as e:
-    pass

--- a/pyroSAR/gamma/util.py
+++ b/pyroSAR/gamma/util.py
@@ -41,13 +41,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
-from .api import diff, disp, isp
-
-# the LAT module is not necessarily needed by this module
-try:
-    from .api import lat
-except ImportError:
-    pass
+from .api import diff, disp, isp, lat
 
 
 def calibrate(id, directory, return_fnames=False,
@@ -1027,7 +1021,7 @@ def geocode(scene, dem, tmpdir, outdir, spacing, scaling='linear', func_geoback=
     ######################################################################
     log.info('applying rtc and back-geocoding')
     for image in images:
-        if 'lat' in locals():
+        if hasattr(lat, 'product'):
             lat.product(data_1=image,
                         data_2=n.pix_ratio,
                         product=image + '_gamma0-rtc',
@@ -1066,7 +1060,7 @@ def geocode(scene, dem, tmpdir, outdir, spacing, scaling='linear', func_geoback=
             else:
                 width = reference_par.range_samples
                 refpar = reference + '.par'
-            if 'lat' in locals():
+            if hasattr(lat, 'linear_to_dB'):
                 lat.linear_to_dB(data_in=data_in,
                                  data_out=data_in + '_db',
                                  width=width,
@@ -1496,7 +1490,7 @@ def pixel_area_wrap(image, namespace, lut, exist_ok=False,
         c1 = not os.path.isfile(namespace.pix_ratio)
         c2 = os.path.isfile(namespace.pix_ratio) and not exist_ok
         if c1 or c2:
-            if 'lat' in locals():
+            if hasattr(lat, 'ratio'):
                 lat.ratio(d1=namespace.pix_ellip_sigma0,
                           d2=namespace.pix_area_gamma0,
                           ratio=namespace.pix_ratio,
@@ -1517,7 +1511,7 @@ def pixel_area_wrap(image, namespace, lut, exist_ok=False,
         c1 = not os.path.isfile(namespace.gs_ratio)
         c2 = os.path.isfile(namespace.gs_ratio) and not exist_ok
         if c1 or c2:
-            if 'lat' in locals():
+            if hasattr(lat, 'ratio'):
                 lat.ratio(d1=namespace.pix_area_gamma0,
                           d2=namespace.pix_area_sigma0,
                           ratio=namespace.gs_ratio,


### PR DESCRIPTION
https://github.com/johntruckenbrodt/pyroSAR/pull/430 made several changes to the GAMMA parsing mechanism.
As a result, the GAMMA modules were no longer able to be imported. This is generally fine except for sphinx building.

With this PR, the parsed `gamma.api` modules like `diff` can regularly be imported. Only if a function of them is executed (e.g. `diff.gc_map2`), an error is raised that the module is not installed.